### PR TITLE
Remove mandel references in appbase submodule

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-eosnetworkfoundation/appbase
+AntelopeIO/appbase
 
 Copyright (c) 2021-2022 EOS Network Foundation (ENF) and its contributors.  All rights reserved. 
 This ENF software is based upon:


### PR DESCRIPTION
Replace mandel-appbase with appbase in LICENSE.md.