### PR TITLE
Support support multiple application instances per exe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,10 +10,10 @@ file(GLOB HEADERS "include/appbase/*.hpp")
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS "ON")
 
-if(CMAKE_CXX_STANDARD EQUAL 98 OR CMAKE_CXX_STANDARD LESS 14)
-   message(FATAL_ERROR "appbase requires c++14 or newer")
+if(CMAKE_CXX_STANDARD EQUAL 98 OR CMAKE_CXX_STANDARD LESS 17)
+   message(FATAL_ERROR "appbase requires c++17 or newer")
 elseif(NOT CMAKE_CXX_STANDARD)
-   set(CMAKE_CXX_STANDARD 14)
+   set(CMAKE_CXX_STANDARD 17)
    set(CMAKE_CXX_STANDARD_REQUIRED ON)
 endif()
 
@@ -82,3 +82,4 @@ install( TARGETS
 )
 
 add_subdirectory( examples )
+add_subdirectory( tests )

--- a/README.md
+++ b/README.md
@@ -87,7 +87,9 @@ exited cleanly
 
 ### Plugin registration
 
-Plugins can be registered by calling `appbase::app().register_plugin()`. When registering a plugin, all other plugins marked as being dependent via the macro `APPBASE_PLUGIN_REQUIRES()` are also registered. See `main.cpp` [example](https://github.com/AntelopeIO/appbase/blob/main/examples/main.cpp).
+Plugins can be registered by calling `appbase::application::register_plugin()`. When registering a plugin, all other plugins marked as being dependent via the macro `APPBASE_PLUGIN_REQUIRES()` are also registered. See `main.cpp` [example](https://github.com/AntelopeIO/appbase/blob/main/examples/main.cpp).
+
+> Note: plugins should be initialized before `initialize()` is called.
 
 ### Boost ASIO 
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,9 @@ exited cleanly
 ```
 
 
-An alternate method for registering plugins is by initializing a static variable with result of the call to `appbase::app().register_plugin<net_plugin>();`. Since this variable is not used, we recomment using the `auto` type, as shown in the `main.cpp` example.
+### Plugin registration
+
+Plugins can be registered by calling `appbase::app().register_plugin()`. When registering a plugin, all other plugins marked as being dependent via the macro `APPBASE_PLUGIN_REQUIRES()` are also registered. See `main.cpp` [example](https://github.com/AntelopeIO/appbase/blob/main/examples/main.cpp).
 
 ### Boost ASIO 
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ class net_plugin : public appbase::plugin<net_plugin>
 
 int main( int argc, char** argv ) {
    try {
-      appbase::app().register_plugin<net_plugin>(); // implict registration of chain_plugin dependency
+      appbase::app().register_plugin<net_plugin>(); // implicit registration of chain_plugin dependency
       if( !appbase::app().initialize( argc, argv ) )
          return -1;
       appbase::app().startup();
@@ -83,6 +83,9 @@ shutdown net plugin
 shutdown chain plugin
 exited cleanly
 ```
+
+
+An alternate method for registering plugins is by initializing a static variable with result of the call to `appbase::app().register_plugin<net_plugin>();`. Since this variable is not used, we recomment using the `auto` type, as shown in the `main.cpp` example.
 
 ### Boost ASIO 
 

--- a/application.cpp
+++ b/application.cpp
@@ -417,11 +417,17 @@ bool application::initialize_impl(int argc, char** argv, vector<abstract_plugin*
 void application::shutdown() {
    for(auto ritr = running_plugins.rbegin();
        ritr != running_plugins.rend(); ++ritr) {
-      (*ritr)->shutdown();
+      try {
+         (*ritr)->shutdown();
+      } catch(...) {
+      }
    }
    for(auto ritr = running_plugins.rbegin();
        ritr != running_plugins.rend(); ++ritr) {
-      plugins.erase((*ritr)->name());
+      try {
+         plugins.erase((*ritr)->name());
+      } catch(...) {
+      }
    }
    running_plugins.clear();
    initialized_plugins.clear();

--- a/application.cpp
+++ b/application.cpp
@@ -464,15 +464,19 @@ void application::exec() {
       while( more || io_serv->run_one() ) {
          if (my->_is_quiting)
             break;
-         while( io_serv->poll_one() ) {}
-         // execute the highest priority item
-         more = pri_queue.execute_highest();
+         try {
+            while( io_serv->poll_one() ) {}
+            // execute the highest priority item
+            more = pri_queue.execute_highest();
+         } catch(...) {
+            more = false;
+            quit();
+         }
       }
       pri_queue.clear(); // make sure the queue is empty
 
       shutdown(); /// perform synchronous shutdown
    }
-   io_serv.reset();
    app_instance.reset(); // deleting *this... make sure it is the last thing we do.
 }
 

--- a/application.cpp
+++ b/application.cpp
@@ -90,8 +90,6 @@ class application_impl {
 
 application::application()
 :my(new application_impl()){
-   io_serv = std::make_shared<boost::asio::io_service>();
-
    register_config_type<std::string>();
    register_config_type<bool>();
    register_config_type<unsigned short>();
@@ -465,7 +463,7 @@ void application::shutdown() {
 
 void application::quit() {
    my->_is_quiting = true;
-   io_serv->stop();
+   io_serv.stop();
 }
 
 bool application::is_quiting() const {
@@ -492,16 +490,16 @@ void application::set_thread_priority_max() {
 
 void application::exec() {
    {
-      boost::asio::io_service::work work(*io_serv);
+      boost::asio::io_service::work work(io_serv);
       (void)work;
       bool more = true;
       std::exception_ptr eptr = nullptr;
       
-      while( more || io_serv->run_one() ) {
+      while( more || io_serv.run_one() ) {
          if (my->_is_quiting)
             break;
          try {
-            while( io_serv->poll_one() ) {}
+            while( io_serv.poll_one() ) {}
             // execute the highest priority item
             more = pri_queue.execute_highest();
          } catch(...) {

--- a/application.cpp
+++ b/application.cpp
@@ -466,7 +466,7 @@ void application::exec() {
          // execute the highest priority item
          more = pri_queue.execute_highest();
       }
-      pri_queue.clear(); // if io_serv->stop() was called, queue may not be empty and hold io_serv pointers
+      pri_queue.execute_all(); // make sure the queue is empty
 
       shutdown(); /// perform synchronous shutdown
    }

--- a/application.cpp
+++ b/application.cpp
@@ -466,6 +466,7 @@ void application::exec() {
          // execute the highest priority item
          more = pri_queue.execute_highest();
       }
+      pri_queue.clear(); // if io_serv->stop() was called, queue may not be empty and hold io_serv pointers
 
       shutdown(); /// perform synchronous shutdown
    }

--- a/application.cpp
+++ b/application.cpp
@@ -462,6 +462,8 @@ void application::exec() {
       (void)work;
       bool more = true;
       while( more || io_serv->run_one() ) {
+         if (my->_is_quiting)
+            break;
          while( io_serv->poll_one() ) {}
          // execute the highest priority item
          more = pri_queue.execute_highest();

--- a/application.cpp
+++ b/application.cpp
@@ -217,11 +217,10 @@ void application::start_sighup_handler( std::shared_ptr<boost::asio::signal_set>
 #endif
 }
 
-std::unique_ptr<application> application::app_instance;
+std::unique_ptr<application> application::app_instance; // static
 
 application& application::instance() {
-   //if (__builtin_expect(!app_instance || app_instance->should_reset, 0))
-   if (app_instance && !app_instance->should_reset)
+   if (__builtin_expect((app_instance && !app_instance->should_reset), 1))
       return *app_instance;
    app_instance.reset(nullptr); // delete old application first
    app_instance.reset(new application);

--- a/application.cpp
+++ b/application.cpp
@@ -506,7 +506,7 @@ void application::exec() {
             // execute the highest priority item
             more = pri_queue.execute_highest();
          } catch(...) {
-            more = false;
+            more = true; // so we exit the while loop without calling io_serv.run_one()
             quit();
             eptr = std::current_exception();
             handle_exception(eptr, "application loop");

--- a/application.cpp
+++ b/application.cpp
@@ -466,7 +466,7 @@ void application::exec() {
          // execute the highest priority item
          more = pri_queue.execute_highest();
       }
-      pri_queue.execute_all(); // make sure the queue is empty
+      pri_queue.clear(); // make sure the queue is empty
 
       shutdown(); /// perform synchronous shutdown
    }

--- a/application.cpp
+++ b/application.cpp
@@ -522,8 +522,6 @@ void application::exec() {
       }
    }
    
-   app_instance.reset(); // deleting *this... make sure it is the last thing we do with application
-   
    // if we caught an exception while in the application loop, rethrow it so that main()
    // can catch it and report the error
    if (eptr)

--- a/application.cpp
+++ b/application.cpp
@@ -218,9 +218,8 @@ void application::start_sighup_handler( std::shared_ptr<boost::asio::signal_set>
 }
 
 application& application::instance() {
-   if (__builtin_expect((app_instance && !app_instance->should_reset), 1))
+   if (__builtin_expect(!!app_instance, 1))
       return *app_instance;
-   app_instance.reset(nullptr); // delete old application first
    app_instance.reset(new application);
    return *app_instance;
 }
@@ -471,7 +470,7 @@ void application::exec() {
       shutdown(); /// perform synchronous shutdown
    }
    io_serv.reset();
-   should_reset = true;
+   app_instance.reset(); // deleting *this... make sure it is the last thing we do.
 }
 
 void application::write_default_config(const bfs::path& cfg_file) {

--- a/application.cpp
+++ b/application.cpp
@@ -46,7 +46,7 @@ class application_impl {
          pthread_sigmask(SIG_BLOCK, &blocked_signals, nullptr);
       }
 
-      void get_target_sigset(sigset_t *blocked_signals) {
+      void get_target_sigset(sigset_t* blocked_signals) {
          sigemptyset(blocked_signals);
          sigaddset(blocked_signals, SIGINT);
          sigaddset(blocked_signals, SIGTERM);

--- a/application.cpp
+++ b/application.cpp
@@ -217,8 +217,6 @@ void application::start_sighup_handler( std::shared_ptr<boost::asio::signal_set>
 #endif
 }
 
-std::unique_ptr<application> application::app_instance; // static
-
 application& application::instance() {
    if (__builtin_expect((app_instance && !app_instance->should_reset), 1))
       return *app_instance;

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -61,11 +61,11 @@ class net_plugin : public appbase::plugin<net_plugin>
 
 };
 
-static auto _net_plugin = appbase::app().register_plugin<net_plugin>(); 
+static auto _net_plugin = appbase::app().register_plugin<net_plugin>(); // register plugin by initializing a static variable
 
 int test(int argc, char** argv) {
    try {
-      // appbase::app().register_plugin<net_plugin>();
+      // appbase::app().register_plugin<net_plugin>(); // alternate way of registering the plugin
       if( !appbase::app().initialize( argc, argv ) )
          return -1;
       appbase::app().startup();

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -61,11 +61,11 @@ class net_plugin : public appbase::plugin<net_plugin>
 
 };
 
+static auto& _net_plugin = appbase::app().register_plugin<net_plugin>(); 
 
-
-int main( int argc, char** argv ) {
+int test(int argc, char** argv) {
    try {
-      appbase::app().register_plugin<net_plugin>();
+      // appbase::app().register_plugin<net_plugin>();
       if( !appbase::app().initialize( argc, argv ) )
          return -1;
       appbase::app().startup();
@@ -79,4 +79,9 @@ int main( int argc, char** argv ) {
    }
    std::cout << "exited cleanly\n";
    return 0;
+}
+
+int main( int argc, char** argv ) {
+   res = test(argc, argv);
+   return res;
 }

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -82,6 +82,6 @@ int test(int argc, char** argv) {
 }
 
 int main( int argc, char** argv ) {
-   res = test(argc, argv);
+   int res = test(argc, argv);
    return res;
 }

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -61,11 +61,9 @@ class net_plugin : public appbase::plugin<net_plugin>
 
 };
 
-static auto _net_plugin = appbase::app().register_plugin<net_plugin>(); // register plugin by initializing a static variable
-
 int test(int argc, char** argv) {
    try {
-      // appbase::app().register_plugin<net_plugin>(); // alternate way of registering the plugin
+      appbase::app().register_plugin<net_plugin>(); 
       if( !appbase::app().initialize( argc, argv ) )
          return -1;
       appbase::app().startup();

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -61,7 +61,7 @@ class net_plugin : public appbase::plugin<net_plugin>
 
 };
 
-static auto& _net_plugin = appbase::app().register_plugin<net_plugin>(); 
+static auto _net_plugin = appbase::app().register_plugin<net_plugin>(); 
 
 int test(int argc, char** argv) {
    try {

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -62,12 +62,15 @@ class net_plugin : public appbase::plugin<net_plugin>
 };
 
 int test(int argc, char** argv) {
+   appbase::application::register_plugin<net_plugin>(); 
+
    try {
-      appbase::app().register_plugin<net_plugin>(); 
-      if( !appbase::app().initialize( argc, argv ) )
+      appbase::scoped_app app;
+      
+      if( !app->initialize( argc, argv ) )
          return -1;
-      appbase::app().startup();
-      appbase::app().exec();
+      app->startup();
+      app->exec();
    } catch ( const boost::exception& e ) {
       std::cerr << boost::diagnostic_information(e) << "\n";
    } catch ( const std::exception& e ) {

--- a/include/appbase/application.hpp
+++ b/include/appbase/application.hpp
@@ -6,6 +6,8 @@
 #include <boost/filesystem/path.hpp>
 #include <boost/core/demangle.hpp>
 #include <typeindex>
+#include <exception>
+#include <string_view>
 
 namespace appbase {
    namespace bpo = boost::program_options;
@@ -286,6 +288,8 @@ namespace appbase {
 
          void wait_for_signal(std::shared_ptr<boost::asio::signal_set> ss);
          void setup_signal_handling_on_ios(boost::asio::io_service& ios, bool startup);
+
+         void handle_exception(std::exception_ptr eptr, std::string_view origin);
    };
 
    application& app();

--- a/include/appbase/application.hpp
+++ b/include/appbase/application.hpp
@@ -273,6 +273,9 @@ namespace appbase {
 
          std::unique_ptr<class application_impl> my;
 
+         bool should_reset { false };
+         
+         static std::unique_ptr<application> app_instance;
    };
 
    application& app();
@@ -284,14 +287,14 @@ namespace appbase {
          plugin():_name(boost::core::demangle(typeid(Impl).name())){}
          virtual ~plugin(){}
 
-         virtual state get_state()const override         { return _state; }
-         virtual const std::string& name()const override { return _name; }
+         virtual state get_state()const final         { return _state; }
+         virtual const std::string& name()const final { return _name; }
 
          virtual void register_dependencies() {
             static_cast<Impl*>(this)->plugin_requires([&](auto& plug){});
          }
 
-         virtual void initialize(const variables_map& options) override {
+         virtual void initialize(const variables_map& options) final {
             if(_state == registered) {
                _state = initialized;
                static_cast<Impl*>(this)->plugin_requires([&](auto& plug){ plug.initialize(options); });
@@ -302,10 +305,10 @@ namespace appbase {
             assert(_state == initialized); /// if initial state was not registered, final state cannot be initialized
          }
 
-         virtual void handle_sighup() override {
+         virtual void handle_sighup() final {
          }
 
-         virtual void startup() override {
+         virtual void startup() final {
             if(_state == initialized) {
                _state = started;
                static_cast<Impl*>(this)->plugin_requires([&](auto& plug){ plug.startup(); });
@@ -315,7 +318,7 @@ namespace appbase {
             assert(_state == started); // if initial state was not initialized, final state cannot be started
          }
 
-         virtual void shutdown() override {
+         virtual void shutdown() final {
             if(_state == started) {
                _state = stopped;
                //ilog( "shutting down plugin ${name}", ("name",name()) );

--- a/include/appbase/application.hpp
+++ b/include/appbase/application.hpp
@@ -213,7 +213,7 @@ namespace appbase {
           * Do not run io_service in any other threads, as application assumes single-threaded execution in exec().
           * @return io_serivice of application
           */
-         boost::asio::io_service& get_io_service() { return *io_serv; }
+         boost::asio::io_service& get_io_service() { return io_serv; }
 
          /**
           * Post func to run on io_service with given priority.
@@ -224,7 +224,7 @@ namespace appbase {
           */
          template <typename Func>
          auto post( int priority, Func&& func ) {
-            return boost::asio::post(*io_serv, pri_queue.wrap(priority, std::forward<Func>(func)));
+            return boost::asio::post(io_serv, pri_queue.wrap(priority, std::forward<Func>(func)));
          }
 
          /**
@@ -265,7 +265,7 @@ namespace appbase {
          application(); ///< private because application is a singleton that should be accessed via instance()
 
          // members are ordered taking into account that the last one is destructed first
-         std::shared_ptr<boost::asio::io_service>  io_serv;
+         boost::asio::io_service                   io_serv;
          execution_priority_queue                  pri_queue;
 
          std::function<void()>                     sighup_callback;

--- a/include/appbase/application.hpp
+++ b/include/appbase/application.hpp
@@ -247,6 +247,8 @@ namespace appbase {
           */
          void set_thread_priority_max();
 
+         void reset_app_singleton() { app_instance.reset(); }
+
       protected:
          template<typename Impl>
          friend class plugin;

--- a/include/appbase/application.hpp
+++ b/include/appbase/application.hpp
@@ -284,7 +284,7 @@ namespace appbase {
 
          bool should_reset { false };
          
-         static std::unique_ptr<application> app_instance;
+         inline static std::unique_ptr<application> app_instance;
          inline static std::vector<std::function<void ()>> plugin_registrations;
    };
 

--- a/include/appbase/application.hpp
+++ b/include/appbase/application.hpp
@@ -360,4 +360,17 @@ namespace appbase {
       }
    }
 
+   class scoped_app {
+   public:
+      scoped_app() : app_(app()) {}
+      ~scoped_app() { application::reset_app_singleton(); } // destroy app instance so next instance gets a clean one
+
+      // access methods
+      application*       operator->()       { return &app_; }
+      const application* operator->() const { return &app_; }
+
+   private:
+      application& app_;
+   };
+
 }

--- a/include/appbase/application.hpp
+++ b/include/appbase/application.hpp
@@ -315,7 +315,7 @@ namespace appbase {
             assert(_state == initialized); /// if initial state was not registered, final state cannot be initialized
          }
 
-         virtual void handle_sighup() final {
+         virtual void handle_sighup() override {
          }
 
          virtual void startup() final {

--- a/include/appbase/application.hpp
+++ b/include/appbase/application.hpp
@@ -282,8 +282,6 @@ namespace appbase {
 
          std::unique_ptr<class application_impl> my;
 
-         bool should_reset { false };
-         
          inline static std::unique_ptr<application> app_instance;
          inline static std::vector<std::function<void ()>> plugin_registrations;
    };

--- a/include/appbase/application.hpp
+++ b/include/appbase/application.hpp
@@ -247,7 +247,7 @@ namespace appbase {
           */
          void set_thread_priority_max();
 
-         void reset_app_singleton() { app_instance.reset(); }
+         static void reset_app_singleton() { app_instance.reset(); }
 
       protected:
          template<typename Impl>

--- a/include/appbase/application.hpp
+++ b/include/appbase/application.hpp
@@ -105,7 +105,7 @@ namespace appbase {
          template<typename... Plugin>
          bool                 initialize(int argc, char** argv) {
             for (const auto& f : plugin_registrations)
-               f();
+               f(*this);
             return initialize_impl(argc, argv, {find_plugin<Plugin>()...});
          }
 
@@ -156,7 +156,7 @@ namespace appbase {
          template<typename Plugin>
          static auto& register_plugin() {
             static int bogus = 0;
-            plugin_registrations.push_back([]() -> void  { app()._register_plugin<Plugin>(); });
+            plugin_registrations.push_back([](application& app) -> void  { app._register_plugin<Plugin>(); });
             return bogus;
          }
 
@@ -287,7 +287,7 @@ namespace appbase {
          vector<abstract_plugin*>                  running_plugins; ///< stored in the order they were started running
 
          inline static std::unique_ptr<application> app_instance;
-         inline static std::vector<std::function<void ()>> plugin_registrations;
+         inline static std::vector<std::function<void (application&)>> plugin_registrations;
 
          void start_sighup_handler( std::shared_ptr<boost::asio::signal_set> sighup_set );
          void set_program_options();

--- a/include/appbase/execution_priority_queue.hpp
+++ b/include/appbase/execution_priority_queue.hpp
@@ -28,6 +28,11 @@ public:
       handlers_.push(std::move(handler));
    }
 
+   void clear()
+   {
+      handlers_ = prio_queue();
+   }
+   
    void execute_all()
    {
       while (!handlers_.empty()) {
@@ -161,7 +166,8 @@ private:
       }
    };
 
-   std::priority_queue<std::unique_ptr<queued_handler_base>, std::deque<std::unique_ptr<queued_handler_base>>, deref_less> handlers_;
+   using prio_queue = std::priority_queue<std::unique_ptr<queued_handler_base>, std::deque<std::unique_ptr<queued_handler_base>>, deref_less>;
+   prio_queue handlers_;
    std::size_t order_ = std::numeric_limits<size_t>::max(); // to maintain FIFO ordering in queue within priority
 };
 

--- a/include/appbase/plugin.hpp
+++ b/include/appbase/plugin.hpp
@@ -6,7 +6,7 @@
 #include <map>
 
 #define APPBASE_PLUGIN_REQUIRES_VISIT( r, visitor, elem ) \
-  visitor( appbase::app().register_plugin<elem>() ); 
+  visitor( appbase::app()._register_plugin<elem>() ); 
 
 #define APPBASE_PLUGIN_REQUIRES( PLUGINS )                               \
    template<typename Lambda>                                           \

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_executable( basic_test basic_test.cpp )
+target_link_libraries( basic_test appbase ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS} )

--- a/tests/basic_test.cpp
+++ b/tests/basic_test.cpp
@@ -380,7 +380,6 @@ BOOST_AUTO_TEST_CASE(queue_emptied_at_quit)
    std::cout << "num_computed: " << num_computed << "\n";
    BOOST_CHECK(num_computed < 100);
    BOOST_CHECK(shutdown_counter == 2); // make sure both plugins shutdonn correctly,
-                                       // even though there was a throw
 }
 
 

--- a/tests/basic_test.cpp
+++ b/tests/basic_test.cpp
@@ -379,7 +379,7 @@ BOOST_AUTO_TEST_CASE(queue_emptied_at_quit)
 
    std::cout << "num_computed: " << num_computed << "\n";
    BOOST_CHECK(num_computed < 100);
-   BOOST_CHECK(shutdown_counter == 2); // make sure both plugins shutdonn correctly,
+   BOOST_CHECK(shutdown_counter == 2); // make sure both plugins shutdown correctly,
 }
 
 

--- a/tests/basic_test.cpp
+++ b/tests/basic_test.cpp
@@ -1,0 +1,150 @@
+#include <appbase/application.hpp>
+#include <iostream>
+#include <string_view>
+#include <thread>
+#include <future>
+#include <boost/exception/diagnostic_information.hpp>
+
+
+#define BOOST_TEST_MODULE Basic Tests
+#include <boost/test/included/unit_test.hpp>
+
+namespace bu = boost::unit_test;
+namespace bpo = boost::program_options;
+
+using bpo::options_description;
+using bpo::variables_map;
+using std::string;
+using std::vector;
+
+class pluginA : public appbase::plugin<pluginA>
+{
+public:
+   APPBASE_PLUGIN_REQUIRES();
+
+   virtual void set_program_options( options_description& cli, options_description& cfg ) override
+   {
+      cli.add_options()
+         ("readonly", "open db in read only mode")
+         ("dbsize", bpo::value<uint64_t>()->default_value( 8*1024 ), "Minimum size MB of database shared memory file")
+         ("replay", "clear db and replay all blocks" )
+         ("log", "log messages" );
+   }
+
+   void plugin_initialize( const variables_map& options ) {
+      readonly_ = !!options.count("readonly");
+      replay_   = !!options.count("replay");
+      log_      = !!options.count("log");
+      dbsize_   = options.at("dbsize").as<uint64_t>();
+      log("initialize pluginA");
+   }
+   
+   void plugin_startup()  { log("starting pluginA"); }
+   void plugin_shutdown() { log("shutdown pluginA"); }
+   
+   uint64_t dbsize() const { return dbsize_; }
+   bool     readonly() const { return readonly_; }
+   
+   void     log(std::string_view s) const {
+      if (log_)
+         std::cout << s << "\n";
+   }
+
+private:
+   bool     readonly_ {false};
+   bool     replay_ {false};
+   bool     log_ {false};
+   uint64_t dbsize_ {0};
+};
+
+class pluginB : public appbase::plugin<pluginB>
+{
+public:
+   pluginB(){};
+   ~pluginB(){};
+
+   APPBASE_PLUGIN_REQUIRES( (pluginA) );
+
+   virtual void set_program_options( options_description& cli, options_description& cfg ) override
+   {
+      cli.add_options()
+         ("endpoint", bpo::value<string>()->default_value( "127.0.0.1:9876" ), "address and port.")
+         ("log2", "log messages" );
+   }
+
+   void plugin_initialize( const variables_map& options ) {
+      endpoint_ = options.at("endpoint").as<string>();
+      log_      = !!options.count("log");
+      log("initialize pluginB");
+   }
+   
+   void plugin_startup()  { log("starting pluginB"); }
+   void plugin_shutdown() { log("shutdown pluginB"); }
+
+   const string& endpoint() const { return endpoint_; }
+   
+   void     log(std::string_view s) const {
+      if (log_)
+         std::cout << s << "\n";
+   }
+   
+private:
+   bool   log_ {false};
+   string endpoint_;
+};
+
+
+BOOST_AUTO_TEST_CASE(program_options)
+{
+   auto& app = appbase::app();
+   
+   app.register_plugin<pluginB>();
+
+   const char *argv[] = { bu::framework::current_test_case().p_name->c_str(),
+                          "--plugin", "pluginA", "--readonly", "--replay", "--dbsize", "10000",
+                          "--plugin", "pluginB", "--endpoint", "127.0.0.1:55" };
+   
+   BOOST_CHECK(app.initialize(sizeof(argv) / sizeof(char *), const_cast<char **>(argv)));
+
+   auto& pA = app.get_plugin<pluginA>();
+   BOOST_CHECK(pA.dbsize() == 10000);
+   BOOST_CHECK(pA.readonly());
+
+   auto& pB = app.get_plugin<pluginB>();
+   BOOST_CHECK(pB.endpoint() == "127.0.0.1:55");
+
+   app.reset_app_singleton(); // needed if we don't call app.exec();
+}
+
+BOOST_AUTO_TEST_CASE(app_execution)
+{
+   auto& app = appbase::app();
+   
+   app.register_plugin<pluginB>();
+
+   const char *argv[] = { bu::framework::current_test_case().p_name->c_str(),
+                          "--plugin", "pluginA", "--log",
+                          "--plugin", "pluginB", "--log2" };
+   
+   BOOST_CHECK(app.initialize(sizeof(argv) / sizeof(char *), const_cast<char **>(argv)));
+
+   std::promise<std::tuple<pluginA&, pluginB&>> plugin_promise;
+   std::future<std::tuple<pluginA&, pluginB&>> plugin_fut = plugin_promise.get_future();
+   std::thread app_thread( [&]() {
+      app.startup();
+      plugin_promise.set_value( {app.get_plugin<pluginA>(), app.get_plugin<pluginB>()} );
+      app.exec();
+   } );
+
+   auto [pA, pB] = plugin_fut.get();
+   BOOST_CHECK(pA.get_state() == appbase::abstract_plugin::started);
+   BOOST_CHECK(pB.get_state() == appbase::abstract_plugin::started);
+
+   app.quit(); // can't use app after app.quit()
+   app_thread.join();
+}
+
+
+
+
+

--- a/tests/basic_test.cpp
+++ b/tests/basic_test.cpp
@@ -262,6 +262,7 @@ BOOST_AUTO_TEST_CASE(exception_in_shutdown)
    
    app_thread.join();
 
-   BOOST_CHECK(shutdown_counter == 2); // make sure both plugins shutdonn correctly
+   BOOST_CHECK(shutdown_counter == 2); // make sure both plugins shutdonn correctly,
+                                       // even though there was a throw
 }
 

--- a/tests/basic_test.cpp
+++ b/tests/basic_test.cpp
@@ -22,8 +22,7 @@ class pluginA : public appbase::plugin<pluginA>
 public:
    APPBASE_PLUGIN_REQUIRES();
 
-   virtual void set_program_options( options_description& cli, options_description& cfg ) override
-   {
+   virtual void set_program_options( options_description& cli, options_description& cfg ) override {
       cli.add_options()
          ("readonly", "open db in read only mode")
          ("dbsize", bpo::value<uint64_t>()->default_value( 8*1024 ), "Minimum size MB of database shared memory file")
@@ -54,11 +53,11 @@ public:
    }
 
 private:
-   bool     readonly_ {false};
-   bool     replay_ {false};
-   bool     log_ {false};
-   uint64_t dbsize_ {0};
-   uint32_t *shutdown_counter { nullptr };
+   bool      readonly_ {false};
+   bool      replay_ {false};
+   bool      log_ {false};
+   uint64_t  dbsize_ {0};
+   uint32_t* shutdown_counter { nullptr };
 };
 
 class pluginB : public appbase::plugin<pluginB>
@@ -69,8 +68,7 @@ public:
 
    APPBASE_PLUGIN_REQUIRES( (pluginA) );
 
-   virtual void set_program_options( options_description& cli, options_description& cfg ) override
-   {
+   virtual void set_program_options( options_description& cli, options_description& cfg ) override {
       cli.add_options()
          ("endpoint", bpo::value<string>()->default_value( "127.0.0.1:9876" ), "address and port.")
          ("log2", "log messages" );
@@ -98,7 +96,7 @@ public:
 private:
    bool   log_ {false};
    string endpoint_;
-   uint32_t *shutdown_counter { nullptr };
+   uint32_t* shutdown_counter { nullptr };
 };
 
 
@@ -108,11 +106,11 @@ BOOST_AUTO_TEST_CASE(program_options)
    
    app.register_plugin<pluginB>();
 
-   const char *argv[] = { bu::framework::current_test_case().p_name->c_str(),
+   const char* argv[] = { bu::framework::current_test_case().p_name->c_str(),
                           "--plugin", "pluginA", "--readonly", "--replay", "--dbsize", "10000",
                           "--plugin", "pluginB", "--endpoint", "127.0.0.1:55" };
    
-   BOOST_CHECK(app.initialize(sizeof(argv) / sizeof(char *), const_cast<char **>(argv)));
+   BOOST_CHECK(app.initialize(sizeof(argv) / sizeof(char*), const_cast<char**>(argv)));
 
    auto& pA = app.get_plugin<pluginA>();
    BOOST_CHECK(pA.dbsize() == 10000);
@@ -130,11 +128,11 @@ BOOST_AUTO_TEST_CASE(app_execution)
    
    app.register_plugin<pluginB>();
 
-   const char *argv[] = { bu::framework::current_test_case().p_name->c_str(),
+   const char* argv[] = { bu::framework::current_test_case().p_name->c_str(),
                           "--plugin", "pluginA", "--log",
                           "--plugin", "pluginB", "--log2" };
    
-   BOOST_CHECK(app.initialize(sizeof(argv) / sizeof(char *), const_cast<char **>(argv)));
+   BOOST_CHECK(app.initialize(sizeof(argv) / sizeof(char*), const_cast<char**>(argv)));
 
    std::promise<std::tuple<pluginA&, pluginB&>> plugin_promise;
    std::future<std::tuple<pluginA&, pluginB&>> plugin_fut = plugin_promise.get_future();

--- a/tests/basic_test.cpp
+++ b/tests/basic_test.cpp
@@ -119,10 +119,10 @@ private:
 // -----------------------------------------------------------------------------
 BOOST_AUTO_TEST_CASE(program_options)
 {
+   appbase::application::register_plugin<pluginB>();
+
    appbase::scoped_app app;
    
-   app->register_plugin<pluginB>();
-
    const char* argv[] = { bu::framework::current_test_case().p_name->c_str(),
                           "--plugin", "pluginA", "--readonly", "--replay", "--dbsize", "10000",
                           "--plugin", "pluginB", "--endpoint", "127.0.0.1:55", "--throw" };
@@ -142,10 +142,10 @@ BOOST_AUTO_TEST_CASE(program_options)
 // -----------------------------------------------------------------------------
 BOOST_AUTO_TEST_CASE(app_execution)
 {
+   appbase::application::register_plugin<pluginB>();
+
    appbase::scoped_app app;
    
-   app->register_plugin<pluginB>();
-
    const char* argv[] = { bu::framework::current_test_case().p_name->c_str(),
                           "--plugin", "pluginA", "--log",
                           "--plugin", "pluginB", "--log2" };
@@ -176,10 +176,10 @@ BOOST_AUTO_TEST_CASE(app_execution)
 // -----------------------------------------------------------------------------
 BOOST_AUTO_TEST_CASE(exception_in_exec)
 {
+   appbase::application::register_plugin<pluginB>();
+
    appbase::scoped_app app;
    
-   app->register_plugin<pluginB>();
-
    const char* argv[] = { bu::framework::current_test_case().p_name->c_str(),
                           "--plugin", "pluginA", "--log",
                           "--plugin", "pluginB", "--log2" };
@@ -225,10 +225,10 @@ BOOST_AUTO_TEST_CASE(exception_in_exec)
 // -----------------------------------------------------------------------------
 BOOST_AUTO_TEST_CASE(exception_in_shutdown)
 {
+   appbase::application::register_plugin<pluginB>();
+
    appbase::scoped_app app;
    
-   app->register_plugin<pluginB>();
-
    const char* argv[] = { bu::framework::current_test_case().p_name->c_str(),
                           "--plugin", "pluginA", "--log",
                           "--plugin", "pluginB", "--log2", "--throw" };


### PR DESCRIPTION
This change: 
1. allows multiple boost test cases within one executable, where each test case can create and destroy an `appbase` instance, as in:
```
      appbase::app().initialize<chain_plugin, producer_plugin>( argv.size(), (char**) &argv[0] );
      appbase::app().startup();
      // do something
      appbase::app().exec();
```
2. resolves some issues around application termination (ensures shutdown of all plugins, **terminates immediately without draining the queue**)
3. adds some tests for the features above.
4. bumps C++ standard requirement from `C++14` to `C++17`

The main issues resolved are:

1. Application termination
    * when a request is received to terminate the application (by calling `application::quit()`), the processing of io requests is stopped immediately (previously we did drain the queue) and plugins are shutdown. As a result there shouldn't be a delay when  shutting down the app even if many requests are queued in.
    * when shutting down plugins, if one plugin throws an exception, it is caught and the remaining plugins are shutdown. That was not the case previously. Giving all plugins a chance to shutdown properly is inportant, as it could mean a clean state on disk and reliable application restarts.
    * the appbase exec() loop consistently returns the first exception caught.
    
2. For the purpose of running an appbase exec loop multiple times
    * add `appbase::scoped_app` class, a RAII way to access an `application` instance with automatic cleanup of the singleton app when the object is destructed.
    * fix issue with signals not unblocked in `~application_impl()`, preventing signal catching issues in the second instance.
    * delay plugin registration in a vector of lambdas, so that plugins can be registered again in each new application instance.

3. Added a `tests` directory with its associated `CMakeLists.txt`, with a single test file containing the following tests:
    * check that program options in `argv` are correctly passed to plugins
    * check that configured plugins are started correctly
    * check for correct exception handling in main `exec()` loop
    * check for correct exception handling while shutting down plugins