### PR TITLE
Fix clang compile failure due to use of structure binding

### DIFF
--- a/tests/basic_test.cpp
+++ b/tests/basic_test.cpp
@@ -257,7 +257,9 @@ BOOST_AUTO_TEST_CASE(exception_in_exec)
       }
    } );
 
-   auto [pA, pB] = plugin_fut.get();
+   pluginA pA;
+   pluginB pB;
+   std::tie(pA, pB) = plugin_fut.get();
    BOOST_CHECK(pA.get_state() == appbase::abstract_plugin::started);
    BOOST_CHECK(pB.get_state() == appbase::abstract_plugin::started);
 
@@ -306,7 +308,9 @@ BOOST_AUTO_TEST_CASE(exception_in_shutdown)
       }
    } );
 
-   auto [pA, pB] = plugin_fut.get();
+   pluginA pA;
+   pluginB pB;
+   std::tie(pA, pB) = plugin_fut.get();
    BOOST_CHECK(pA.get_state() == appbase::abstract_plugin::started);
    BOOST_CHECK(pB.get_state() == appbase::abstract_plugin::started);
 


### PR DESCRIPTION
Resolve https://github.com/AntelopeIO/leap/issues/703.

Structured bindings are not capturable by lamda. Use tie instead.

Before the fix:

```
/home/leap/libraries/appbase/tests/basic_test.cpp:271:48: error: reference to local binding 'pA' declared in enclosing function 'exception_in_exec::test_method'
   app->post(appbase::priority::high, [&] () { pA.do_throw("throwing in pluginA"); });
                                               ^
/home//leap/libraries/appbase/tests/basic_test.cpp:260:10: note: 'pA' declared here
   auto [pA, pB] = plugin_fut.get();
         ^
/home//leap/libraries/appbase/tests/basic_test.cpp:320:48: error: reference to local binding 'pA' declared in enclosing function 'exception_in_shutdown::test_method'
   app->post(appbase::priority::high, [&] () { pA.do_throw("throwing in pluginA"); });
                                               ^
/home//leap/libraries/appbase/tests/basic_test.cpp:309:10: note: 'pA' declared here
   auto [pA, pB] = plugin_fut.get();
         ^
2 errors generated.
```