### PR TITLE
fix exception_in_exec and exception_in_shutdown test failures

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,2 +1,5 @@
-add_executable( basic_test basic_test.cpp )
-target_link_libraries( basic_test appbase ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS} )
+file(GLOB UNIT_TESTS "*.cpp")
+add_executable( appbase_test ${UNIT_TESTS} )
+target_link_libraries( appbase_test appbase ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS} )
+
+add_test( appbase_test appbase_test )

--- a/tests/basic_test.cpp
+++ b/tests/basic_test.cpp
@@ -257,9 +257,7 @@ BOOST_AUTO_TEST_CASE(exception_in_exec)
       }
    } );
 
-   pluginA pA;
-   pluginB pB;
-   std::tie(pA, pB) = plugin_fut.get();
+   auto [pA, pB] = plugin_fut.get();
    BOOST_CHECK(pA.get_state() == appbase::abstract_plugin::started);
    BOOST_CHECK(pB.get_state() == appbase::abstract_plugin::started);
 
@@ -270,7 +268,7 @@ BOOST_AUTO_TEST_CASE(exception_in_exec)
    std::this_thread::sleep_for(std::chrono::milliseconds(20));
 
    // this will throw an exception causing `app->exec()` to exit
-   app->post(appbase::priority::high, [&] () { pA.do_throw("throwing in pluginA"); });
+   app->post(appbase::priority::high, [&pA=pA] () { pA.do_throw("throwing in pluginA"); });
    
    app_thread.join();
 
@@ -308,9 +306,7 @@ BOOST_AUTO_TEST_CASE(exception_in_shutdown)
       }
    } );
 
-   pluginA pA;
-   pluginB pB;
-   std::tie(pA, pB) = plugin_fut.get();
+   auto [pA, pB] = plugin_fut.get();
    BOOST_CHECK(pA.get_state() == appbase::abstract_plugin::started);
    BOOST_CHECK(pB.get_state() == appbase::abstract_plugin::started);
 
@@ -321,7 +317,7 @@ BOOST_AUTO_TEST_CASE(exception_in_shutdown)
    std::this_thread::sleep_for(std::chrono::milliseconds(20));
 
    // this will throw an exception causing `app->exec()` to exit
-   app->post(appbase::priority::high, [&] () { pA.do_throw("throwing in pluginA"); });
+   app->post(appbase::priority::high, [&pA=pA] () { pA.do_throw("throwing in pluginA"); });
    
    app_thread.join();
 
@@ -385,6 +381,3 @@ BOOST_AUTO_TEST_CASE(queue_emptied_at_quit)
    BOOST_CHECK(num_computed < 100);
    BOOST_CHECK(shutdown_counter == 2); // make sure both plugins shutdown correctly,
 }
-
-
-

--- a/tests/basic_test.cpp
+++ b/tests/basic_test.cpp
@@ -69,6 +69,8 @@ class pluginB : public appbase::plugin<pluginB>
 public:
    pluginB(){};
    ~pluginB(){};
+   pluginB(const pluginB&) = delete;
+   pluginB(pluginB&&) = delete;
 
    APPBASE_PLUGIN_REQUIRES( (pluginA) );
 


### PR DESCRIPTION
Resolved https://github.com/AntelopeIO/appbase/issues/6
1. Fixed `exception_in_exec` and `exception_in_shutdown` test failures. The problem was that `pA` was a local copy and not the plugin being shutdown; `shutdown_counter` was never updated. The fix has been verified in both GCC and Clang.
2. Added `appbase_test` to CICD so the tests always run.

Before the fix:

```
tests/basic_test
Running 6 test cases...
initialize pluginA
initialize pluginB
starting pluginA
starting pluginB
shutdown pluginB
shutdown pluginA
Started first application instance
Started second application instance
initialize pluginA
initialize pluginB
starting pluginA
starting pluginB
Caught application loop exception: "throwing in pluginA"
shutdown pluginB
shutdown pluginA
exception in exec (as expected): throwing in pluginA
/home/lh/work/appbase-shutdown-fix/tests/basic_test.cpp(277): error: in "exception_in_exec": check shutdown_counter == 2 has failed
initialize pluginA
initialize pluginB
starting pluginA
starting pluginB
Caught application loop exception: "throwing in pluginA"
shutdown pluginB
Caught pluginB exception: "throwing in shutdown"
shutdown pluginA
exception in exec (as expected): throwing in pluginA
/home/lh/work/appbase-shutdown-fix/tests/basic_test.cpp(328): error: in "exception_in_shutdown": check shutdown_counter == 2 has failed
num_computed: 0

*** 2 failures are detected in the test module "Basic Tests"
```

After the fix:

t```
ests/appbase_test
Running 6 test cases...
initialize pluginA
initialize pluginB
starting pluginA
starting pluginB
shutdown pluginB
shutdown pluginA
Started first application instance
Started second application instance
initialize pluginA
initialize pluginB
starting pluginA
starting pluginB
Caught application loop exception: "throwing in pluginA"
shutdown pluginB
shutdown pluginA
exception in exec (as expected): throwing in pluginA
initialize pluginA
initialize pluginB
starting pluginA
starting pluginB
Caught application loop exception: "throwing in pluginA"
shutdown pluginB
Caught pluginB exception: "throwing in shutdown"
shutdown pluginA
exception in exec (as expected): throwing in pluginA
num_computed: 0

*** No errors detected
```