### PR TITLE
multiple priority queues support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ plugins are configured, initialized, started, and shutdown in the proper order.
 - Automatically Load Dependent Plugins in Order
 - Plugins can specify commandline arguments and configuration file options
 - Program gracefully exits from SIGINT, SIGTERM, and SIGPIPE
-- Minimal Dependencies (Boost 1.60, c++14)
+- Minimal Dependencies (Boost 1.60, c++17)
 
 ## Defining a Plugin
 
@@ -109,18 +109,25 @@ Use of `get_io_service()` directly is not recommended as the priority queue will
 Because the app calls `io_service::run()` from within `application::exec()` and does not spawn any threads
 all asynchronous operations posted to the io_service should be run in the same thread.  
 
+## Multiple Priority Queues Support
+By default, AppBase maintains one internal priority queue. Users can add additional priority queues
+and manage how functions in the queues are executed. To do so, Call `multi_queue_add_queue` to add
+a new queue and get an ID to reference the queue. Then call `multi_queue_register_next_handler_func` to register a function which returns which queue's top priority function is to be executed. Use `multi_queue_exec` instead of `exec` to start execution loop. `multi_queue_empty`, `multi_queue_size`, and `multi_queue_less_than` are provided for writing a next_handler_func.
+
+See `tests/pri_queue_tests.cpp` for examples.
+
 ## Graceful Exit 
 
 To trigger a graceful exit call `appbase::app().quit()` or send SIGTERM, SIGINT, or SIGPIPE to the process.
 
 ## Dependencies 
 
-1. c++14 or newer  (clang or g++)
-2. Boost 1.60 or newer compiled with C++14 support
+1. c++17 or newer  (clang or g++)
+2. Boost 1.60 or newer compiled with C++17 support
 
-To compile boost with c++14 use:
+To compile boost with c++17 use:
 
 ```
-./b2 ...  cxxflags="-std=c++0x -stdlib=libc++" linkflags="-stdlib=libc++" ...
+./b2 ...  cxxflags="-std=c++17 -stdlib=libc++" linkflags="-stdlib=libc++" ...
 ```
 

--- a/include/appbase/execution_priority_queue.hpp
+++ b/include/appbase/execution_priority_queue.hpp
@@ -16,48 +16,91 @@ struct priority {
    static constexpr int highest     = std::numeric_limits<int>::max();
 };
 
+// the index of the default queue
+constexpr static int default_queue = 0;
+
 class execution_priority_queue : public boost::asio::execution_context
 {
 public:
+   execution_priority_queue()
+   {
+      // add the default queue
+      multi_queue_add_queue();
+   }
 
    template <typename Function>
-   void add(int priority, Function function)
+   void add(int priority, int index, Function function)
    {
       std::unique_ptr<queued_handler_base> handler(new queued_handler<Function>(priority, --order_, std::move(function)));
 
-      handlers_.push(std::move(handler));
+      handlers_queue_[index]->push(std::move(handler));
    }
 
    void clear()
    {
-      handlers_ = prio_queue();
+      for (auto& q: handlers_queue_)
+         q = std::make_unique<prio_queue>();
    }
    
    void execute_all()
    {
-      while (!handlers_.empty()) {
-         handlers_.top()->execute();
-         handlers_.pop();
+      while (!handlers_queue_[default_queue]->empty()) {
+         handlers_queue_[default_queue]->top()->execute();
+         handlers_queue_[default_queue]->pop();
       }
    }
 
    bool execute_highest()
    {
-      if( !handlers_.empty() ) {
-         handlers_.top()->execute();
-         handlers_.pop();
+      if( !handlers_queue_[default_queue]->empty() ) {
+         handlers_queue_[default_queue]->top()->execute();
+         handlers_queue_[default_queue]->pop();
       }
 
-      return !handlers_.empty();
+      return !handlers_queue_[default_queue]->empty();
    }
 
-   size_t size() { return handlers_.size(); }
+   size_t size() { return handlers_queue_[default_queue]->size(); }
+
+   // multi-queue support
+
+   void multi_queue_register_next_handler_func(std::function<std::tuple<bool, int, bool>()> f) {
+      next_handler_func_ = f;
+   }
+
+   int multi_queue_add_queue() {
+      handlers_queue_.push_back( std::make_unique<prio_queue>() );
+      return handlers_queue_.size() - 1; // the index of the queue just added
+   }
+
+   int multi_queue_size(int i) {
+      return handlers_queue_[i]->size();
+   }
+
+   int multi_queue_empty(int i) {
+      return handlers_queue_[i]->empty();
+   }
+
+   bool multi_queue_less_than(int i, int j) {
+      return ( *handlers_queue_[i]->top() < *handlers_queue_[j]->top() );
+   }
+
+   bool multi_queue_execute_highest()
+   {
+      auto [has_handler, i, more] = next_handler_func_();
+      if( has_handler ) {
+         handlers_queue_[i]->top()->execute();
+         handlers_queue_[i]->pop();
+      }
+
+      return more;
+   }
 
    class executor
    {
    public:
-      executor(execution_priority_queue& q, int p)
-            : context_(q), priority_(p)
+      executor(execution_priority_queue& q, int p, int index)
+            : context_(q), priority_(p), index_(index)
       {
       }
 
@@ -69,19 +112,19 @@ public:
       template <typename Function, typename Allocator>
       void dispatch(Function f, const Allocator&) const
       {
-         context_.add(priority_, std::move(f));
+         context_.add(priority_, index_, std::move(f));
       }
 
       template <typename Function, typename Allocator>
       void post(Function f, const Allocator&) const
       {
-         context_.add(priority_, std::move(f));
+         context_.add(priority_, index_,std::move(f));
       }
 
       template <typename Function, typename Allocator>
       void defer(Function f, const Allocator&) const
       {
-         context_.add(priority_, std::move(f));
+         context_.add(priority_, index_, std::move(f));
       }
 
       void on_work_started() const noexcept {}
@@ -100,13 +143,14 @@ public:
    private:
       execution_priority_queue& context_;
       int priority_;
+      int index_;
    };
 
    template <typename Function>
    boost::asio::executor_binder<Function, executor>
-   wrap(int priority, Function&& func)
+   wrap(int priority, Function&& func, int index = 0)
    {
-      return boost::asio::bind_executor( executor(*this, priority), std::forward<Function>(func) );
+      return boost::asio::bind_executor( executor(*this, priority, index), std::forward<Function>(func) );
    }
 
 private:
@@ -167,8 +211,10 @@ private:
    };
 
    using prio_queue = std::priority_queue<std::unique_ptr<queued_handler_base>, std::deque<std::unique_ptr<queued_handler_base>>, deref_less>;
-   prio_queue handlers_;
    std::size_t order_ = std::numeric_limits<size_t>::max(); // to maintain FIFO ordering in queue within priority
+
+   std::vector<std::unique_ptr<prio_queue>> handlers_queue_;
+   std::function<std::tuple<bool, int, bool>()>  next_handler_func_;
 };
 
 } // appbase

--- a/tests/pri_queue_tests.cpp
+++ b/tests/pri_queue_tests.cpp
@@ -1,0 +1,165 @@
+#include <thread>
+#include <boost/test/unit_test.hpp>
+#include <appbase/application.hpp>
+
+using namespace appbase;
+
+BOOST_AUTO_TEST_SUITE(pri_queues)
+
+constexpr static int q0 = appbase::default_queue;
+
+// start app thread and call execution loop based on use_default_queue flag 
+std::thread start_app_thread(appbase::scoped_app& app, bool use_default_queue) {
+   const char* argv[] = { boost::unit_test::framework::current_test_case().p_name->c_str() };
+   BOOST_CHECK(app->initialize(sizeof(argv) / sizeof(char*), const_cast<char**>(argv)));
+   app->startup();
+   std::thread app_thread( [&, use_default_queue]() {
+      if ( use_default_queue ) {
+         app->exec();
+      } else {
+         app->multi_queue_exec();
+      }
+   } );
+   return app_thread;
+}
+
+// wait for time out or the number of results has reached
+void wait_for_results(const std::vector<int>& results, size_t expected) {
+   auto i = 0;
+   while ( i < 10 && results.size() < expected) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      ++i;
+   }
+}
+
+// test single default queue
+BOOST_AUTO_TEST_CASE( default_single_queue ) {
+   // start app thread with default queue
+   appbase::scoped_app app;
+   auto app_thread = start_app_thread(app, true);
+
+   // post functions. each function pushs a value into the results queue
+   std::vector<int> results;
+   app->post( priority::medium, [&results]() { results.emplace_back(1); } );
+   app->post( priority::medium, [&results]() { results.emplace_back(2); } );
+   app->post( priority::high,   [&results]() { results.emplace_back(3); } );
+   app->post( priority::lowest, [&results]() { results.emplace_back(4); } );
+   app->post( priority::low,    [&results]() { results.emplace_back(5); } );
+   app->post( priority::low,    [&results]() { results.emplace_back(6); } );
+
+   // wait until app thread has executed all the functions
+   auto num_rslts_expected = 6;
+   wait_for_results(results, num_rslts_expected);
+   app->quit();
+   app_thread.join();
+   
+   // make sure functions are executed in right order
+   BOOST_REQUIRE_EQUAL( results.size(), num_rslts_expected );
+   BOOST_REQUIRE_EQUAL( results[0], 3 );
+   BOOST_REQUIRE_EQUAL( results[1], 1 );
+   BOOST_REQUIRE_EQUAL( results[2], 2 );
+   BOOST_REQUIRE_EQUAL( results[3], 5 );
+   BOOST_REQUIRE_EQUAL( results[4], 6 );
+   BOOST_REQUIRE_EQUAL( results[5], 4 );
+}
+
+// two subqueues: execute from only one queue
+BOOST_AUTO_TEST_CASE( execute_from_one_subqueue ) {
+   appbase::scoped_app app;
+   auto app_thread = start_app_thread(app, false);
+
+   auto q1 = app->multi_queue_add_queue();
+   auto next = [&app, q1]() {
+      // only execute functions from q1
+      return std::make_tuple(!app->multi_queue_empty(q1), q1, app->multi_queue_size(q1) > 1);
+   };
+   app->multi_queue_register_next_handler_func(next);
+
+   std::vector<int> results;
+   app->post( priority::medium,  [&results]() { results.emplace_back(1); }, q0 );
+   app->post( priority::medium,  [&results]() { results.emplace_back(2); }, q1 );
+   app->post( priority::high,    [&results]() { results.emplace_back(3); }, q1 );
+   app->post( priority::lowest,  [&results]() { results.emplace_back(4); }, q0 );
+   app->post( priority::low,     [&results]() { results.emplace_back(5); }, q0 );
+   app->post( priority::low,     [&results]() { results.emplace_back(6); }, q1 );
+   app->post( priority::highest, [&results]() { results.emplace_back(7); }, q0 );
+   app->post( priority::low,     [&results]() { results.emplace_back(8); }, q1 );
+   app->post( priority::low,     [&results]() { results.emplace_back(9); }, q1 );
+
+   auto num_rslts_expected = 5;
+   wait_for_results(results, num_rslts_expected);
+   app->quit();
+   app_thread.join();
+   
+   // queues are emptied after quit
+   BOOST_REQUIRE_EQUAL( app->multi_queue_size(q0), 0);
+   BOOST_REQUIRE_EQUAL( app->multi_queue_size(q1), 0);
+
+   // only queue 1's handlers are executed
+   BOOST_REQUIRE_EQUAL( results.size(), num_rslts_expected ); // only queue 1's handlers executed
+   BOOST_REQUIRE_EQUAL( results[0], 3 );
+   BOOST_REQUIRE_EQUAL( results[1], 2 );
+   BOOST_REQUIRE_EQUAL( results[2], 6 );
+   BOOST_REQUIRE_EQUAL( results[3], 8 );
+   BOOST_REQUIRE_EQUAL( results[4], 9 );
+}
+
+// two multi_queues: execute from both queues in correct priority order
+BOOST_AUTO_TEST_CASE( execute_from_both_multi_queues ) {
+   appbase::scoped_app app;
+   auto app_thread = start_app_thread(app, false);
+
+   auto q1 = app->multi_queue_add_queue();
+   auto next = [&app, q1]() {
+      int index = q0;
+      auto has_handler = false;
+
+      if( !app->multi_queue_empty(q1) && ( app->multi_queue_empty(q0) || app->multi_queue_less_than(q0, q1) ) ) {
+         // q1 non-empty but q0 empty, or q1's top handler's priority greater than q0
+         index = q1;
+         has_handler = true;
+      } else if( !app->multi_queue_empty(q0) ) {
+         index = q0;
+         has_handler = true;
+      }
+      auto more = ( app->multi_queue_size(q0) + app->multi_queue_size(q1) > 1 );
+      return std::make_tuple(has_handler, index, more);
+   };
+   app->multi_queue_register_next_handler_func(next);
+
+   std::vector<int> results;
+   app->post( priority::medium,  [&results]() { results.emplace_back(1); }, q0 );
+   app->post( priority::medium,  [&results]() { results.emplace_back(2); }, q1 );
+   app->post( priority::high,    [&results]() { results.emplace_back(3); }, q1 );
+   app->post( priority::lowest,  [&results]() { results.emplace_back(4); }, q0 );
+   app->post( priority::low,     [&results]() { results.emplace_back(5); }, q0 );
+   app->post( priority::low,     [&results]() { results.emplace_back(6); }, q1 );
+   app->post( priority::highest, [&results]() { results.emplace_back(7); }, q0 );
+   app->post( priority::low,     [&results]() { results.emplace_back(8); }, q1 );
+   app->post( priority::lowest,  [&results]() { results.emplace_back(9); }, q0 );
+   app->post( priority::low,     [&results]() { results.emplace_back(0); }, q1 );
+
+   auto num_rslts_expected = 10;
+   wait_for_results(results, num_rslts_expected);
+   app->quit();
+   app_thread.join();
+
+   // queues are emptied after quit
+   BOOST_REQUIRE_EQUAL( app->multi_queue_size(q0), 0);
+   BOOST_REQUIRE_EQUAL( app->multi_queue_size(q1), 0);
+
+   // all handlers are executed in right order among both queues
+   BOOST_REQUIRE_EQUAL( results.size(), num_rslts_expected );
+   BOOST_REQUIRE_EQUAL( results[0], 7 );
+   BOOST_REQUIRE_EQUAL( results[1], 3 );
+   BOOST_REQUIRE_EQUAL( results[2], 1 );
+   BOOST_REQUIRE_EQUAL( results[3], 2 );
+   BOOST_REQUIRE_EQUAL( results[4], 5 );
+   BOOST_REQUIRE_EQUAL( results[5], 6 );
+   BOOST_REQUIRE_EQUAL( results[6], 8 );
+   BOOST_REQUIRE_EQUAL( results[7], 0 );
+   BOOST_REQUIRE_EQUAL( results[8], 4 );
+   BOOST_REQUIRE_EQUAL( results[9], 9 );
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This is a part of the parallelizing read-only transaction execution effort (https://github.com/eosnetworkfoundation/product/blob/main/transactions/read-only/parallel.md)

With multiple priority queues support, users can add additional priority queues into AppBase, decide which queue a function is posted to, and manage how functions in the queues are executed. To do so, Call `multi_queue_add_queue` to add a new queue and get an ID to reference the queue. Then call `multi_queue_register_next_handler_func` to register a function which returns which queue's top priority function is to be executed at the time of the call. Use `multi_queue_exec` instead of `exec` to start execution loop. `multi_queue_empty`, `multi_queue_size`,  and `multi_queue_less_than` are provided to help writing a next_handler_func.

See `tests/pri_queue_tests.cpp` for example uses.