### PR TITLE
Add optional initialize_logging to initialize so logging is available before initialization

### DIFF
--- a/application_base.cpp
+++ b/application_base.cpp
@@ -253,7 +253,7 @@ void application_base::set_program_options()
    my->_app_options.add(app_cli_opts);
 }
 
-bool application_base::initialize_impl(int argc, char** argv, vector<abstract_plugin*> autostart_plugins) {
+bool application_base::initialize_impl(int argc, char** argv, vector<abstract_plugin*> autostart_plugins, std::function<void()> initialize_logging) {
    set_program_options();
 
    bpo::variables_map& options = my->_options;
@@ -377,6 +377,10 @@ bool application_base::initialize_impl(int argc, char** argv, vector<abstract_pl
       std::cerr << "         Explicit values will override future changes to application defaults. Consider commenting out or" << std::endl;
       std::cerr << "         removing these items." << std::endl;
    }
+
+   // Initialize user provided logging now so it is available during plugins' initialization
+   if (initialize_logging)
+      initialize_logging();
 
    if(options.count("plugin") > 0)
    {

--- a/include/appbase/application_base.hpp
+++ b/include/appbase/application_base.hpp
@@ -104,13 +104,14 @@ public:
     *
     * @tparam Plugin List of plugins to initalize even if not mentioned by configuration. For plugins started by
     * configuration settings or dependency resolution, this template has no effect.
+    * @param initialize_logging Function pointer that will be invoked to initialize logging
     * @return true if the application and plugins were initialized, false or exception on error
     */
    template <typename... Plugin>
-   bool initialize(int argc, char** argv) {
+   bool initialize(int argc, char** argv, std::function<void()> initialize_logging={}) {
       for (const auto& f : plugin_registrations)
          f(*this);
-      return initialize_impl(argc, argv, {find_plugin<Plugin>()...});
+      return initialize_impl(argc, argv, {find_plugin<Plugin>()...}, initialize_logging);
    }
 
    void startup(boost::asio::io_service& io_serv);
@@ -274,7 +275,7 @@ protected:
    template <typename Impl>
    friend class plugin;
 
-   bool initialize_impl(int argc, char** argv, vector<abstract_plugin*> autostart_plugins);
+   bool initialize_impl(int argc, char** argv, vector<abstract_plugin*> autostart_plugins, std::function<void()> initialize_logging);
 
    /** these notifications get called from the plugin when their state changes so that
     * the application can call shutdown in the reverse order.


### PR DESCRIPTION
https://github.com/AntelopeIO/leap/pull/752 moved  `initalize_logging`() before `app->initialize()` so logging is ready before plugin initialization. Unfortunately `logging_conf` was not set until after `app->initialize()`. This caused `logging_conf` configuration not to take any effect https://github.com/AntelopeIO/leap/issues/775.

Two solutions were considered:
1. Add an optional initialize_logging function parameter to app->initialize() which is called after logging_conf is set and before plugins are initialized.
2. Split app->initialize into init_args and init_plugins. The user calls his own init_logging between the two calls.

The first solution is chosen as it is simpler, minimal changes, no backward compatibility issue, and hiding the details of initialization order.

Leap nodes and other programs will be updated after this PR.

In testing, before the change:
```
...
info  2023-03-04T14:21:38.642 nodeos    net_plugin.cpp:3810           operator()           ] startin
g listener, max clients is 25
info  2023-03-04T14:21:38.642 nodeos    http_plugin.cpp:132           create_beast_server  ] created
 beast HTTP listener
info  2023-03-04T14:21:38.642 nodeos    http_plugin.cpp:290           operator()           ] start l
istening for http requests (boost::beast) 
...
```

after the change:
```
...
info  2023-03-04T14:38:47.460 nodeos    net_plugin.cpp:3810           operator()           ] starting listen
er, max clients is 25
debug 2023-03-04T14:38:47.461 nodeos    net_plugin.cpp:898            connection           ] new connection
object created
debug 2023-03-04T14:38:47.461 nodeos    net_plugin.cpp:2733           update_chain_info    ] updating chain
info lib 1, head 1, fork 1
info  2023-03-04T14:38:47.461 nodeos    http_plugin.cpp:132           create_beast_server  ] created beast H
TTP listener
info  2023-03-04T14:38:47.461 nodeos    http_plugin.cpp:290           operator()           ] start listening
 for http requests (boost::beast)
...
```