### PR TITLE
Make order external to priority queue

### DIFF
--- a/examples/executor_example/application.hpp
+++ b/examples/executor_example/application.hpp
@@ -22,7 +22,7 @@ class my_executor {
 public:
    template <typename Func>
    auto post( int priority, Func&& func ) {
-      return boost::asio::post(io_serv, pri_queue.wrap(priority, std::forward<Func>(func)));
+      return boost::asio::post(io_serv, pri_queue.wrap(priority, --order, std::forward<Func>(func)));
    }
 
    auto& get_priority_queue() { return pri_queue; }
@@ -37,6 +37,7 @@ private:
    // members are ordered taking into account that the last one is destructed first
    boost::asio::io_service  io_serv;
    appbase::execution_priority_queue pri_queue;
+   std::size_t order = std::numeric_limits<size_t>::max(); // to maintain FIFO ordering in queue within priority
 };
 
 namespace appbase {

--- a/include/appbase/default_executor.hpp
+++ b/include/appbase/default_executor.hpp
@@ -9,7 +9,7 @@ class default_executor {
 public:
    template <typename Func>
    auto post(int priority, Func&& func) {
-      return boost::asio::post(io_serv, pri_queue.wrap(priority, std::forward<Func>(func)));
+      return boost::asio::post(io_serv, pri_queue.wrap(priority, --order, std::forward<Func>(func)));
    }
 
    /**
@@ -44,6 +44,7 @@ private:
    // members are ordered taking into account that the last one is destructed first
    boost::asio::io_service io_serv;
    execution_priority_queue pri_queue;
+   std::size_t order = std::numeric_limits<size_t>::max(); // to maintain FIFO ordering in queue within priority
 };
 
 } // namespace appbase

--- a/include/appbase/execution_priority_queue.hpp
+++ b/include/appbase/execution_priority_queue.hpp
@@ -11,9 +11,9 @@ class execution_priority_queue : public boost::asio::execution_context
 public:
 
    template <typename Function>
-   void add(int priority, Function function)
+   void add(int priority, size_t order, Function function)
    {
-      std::unique_ptr<queued_handler_base> handler(new queued_handler<Function>(priority, --order_, std::move(function)));
+      std::unique_ptr<queued_handler_base> handler(new queued_handler<Function>(priority, order, std::move(function)));
 
       handlers_.push(std::move(handler));
    }
@@ -41,11 +41,17 @@ public:
       return !handlers_.empty();
    }
 
+   size_t size() const { return handlers_.size(); }
+
+   bool empty() const { return handlers_.empty(); }
+
+   const auto& top() const { return handlers_.top(); }
+
    class executor
    {
    public:
-      executor(execution_priority_queue& q, int p)
-            : context_(q), priority_(p)
+      executor(execution_priority_queue& q, int p, size_t o)
+            : context_(q), priority_(p), order_(o)
       {
       }
 
@@ -57,19 +63,19 @@ public:
       template <typename Function, typename Allocator>
       void dispatch(Function f, const Allocator&) const
       {
-         context_.add(priority_, std::move(f));
+         context_.add(priority_, order_, std::move(f));
       }
 
       template <typename Function, typename Allocator>
       void post(Function f, const Allocator&) const
       {
-         context_.add(priority_, std::move(f));
+         context_.add(priority_, order_, std::move(f));
       }
 
       template <typename Function, typename Allocator>
       void defer(Function f, const Allocator&) const
       {
-         context_.add(priority_, std::move(f));
+         context_.add(priority_, order_, std::move(f));
       }
 
       void on_work_started() const noexcept {}
@@ -77,7 +83,7 @@ public:
 
       bool operator==(const executor& other) const noexcept
       {
-         return &context_ == &other.context_ && priority_ == other.priority_;
+         return order_ == other.order_ && &context_ == &other.context_ && priority_ == other.priority_;
       }
 
       bool operator!=(const executor& other) const noexcept
@@ -88,13 +94,14 @@ public:
    private:
       execution_priority_queue& context_;
       int priority_;
+      size_t order_;
    };
 
    template <typename Function>
    boost::asio::executor_binder<Function, executor>
-   wrap(int priority, Function&& func)
+   wrap(int priority, size_t order, Function&& func)
    {
-      return boost::asio::bind_executor( executor(*this, priority), std::forward<Function>(func) );
+      return boost::asio::bind_executor( executor(*this, priority, order), std::forward<Function>(func) );
    }
 
 private:
@@ -156,7 +163,6 @@ private:
 
    using prio_queue = std::priority_queue<std::unique_ptr<queued_handler_base>, std::deque<std::unique_ptr<queued_handler_base>>, deref_less>;
    prio_queue handlers_;
-   std::size_t order_ = std::numeric_limits<size_t>::max(); // to maintain FIFO ordering in queue within priority
 };
 
 } // appbase


### PR DESCRIPTION
Move the `order` out of priority queue to make it more generic and usable by https://github.com/AntelopeIO/leap/pull/776.