### PR TITLE
Make Priority a template parameter so it is generic.

### DIFF
--- a/examples/executor_example/application.hpp
+++ b/examples/executor_example/application.hpp
@@ -21,7 +21,7 @@
 class my_executor {
 public:
    template <typename Func>
-   auto post( int priority, Func&& func ) {
+   auto post( appbase::default_priority priority, Func&& func ) {
       return boost::asio::post(io_serv, pri_queue.wrap(priority, std::forward<Func>(func)));
    }
 
@@ -36,11 +36,11 @@ public:
 private:
    // members are ordered taking into account that the last one is destructed first
    boost::asio::io_service  io_serv;
-   appbase::execution_priority_queue pri_queue;
+   appbase::execution_priority_queue<appbase::default_priority> pri_queue;
 };
 
 namespace appbase {
-   using application = application_t<my_executor>;
+   using application = application_t<my_executor, appbase::default_priority>;
 }
 
 #include <appbase/application_instance.hpp>

--- a/include/appbase/application.hpp
+++ b/include/appbase/application.hpp
@@ -16,7 +16,7 @@
 #include <appbase/default_executor.hpp>
 
 namespace appbase {
-using application = application_t<default_executor>;
+using application = application_t<default_executor, default_priority>;
 }
 
 #include <appbase/application_instance.hpp>

--- a/include/appbase/application_base.hpp
+++ b/include/appbase/application_base.hpp
@@ -320,7 +320,7 @@ private:
 };
 
 // ------------------------------------------------------------------------------------------
-template <class executor_t>
+template <class executor_t, class priority_t>
 class application_t : public application_base {
 public:
    static application_t& instance() {
@@ -348,7 +348,7 @@ public:
     * @return result of boost::asio::post
     */
    template <typename Func>
-   auto post(int priority, Func&& func) {
+   auto post(priority_t priority, Func&& func) {
       return executor_.post(priority, std::forward<Func>(func));
    }
 
@@ -370,7 +370,7 @@ public:
 
    application_t() {
       set_stop_executor_cb([&]() { get_io_service().stop(); });
-      set_post_cb([&](int prio, std::function<void()> cb) { executor_.post(prio, std::move(cb)); });
+      set_post_cb([&](priority_t prio, std::function<void()> cb) { executor_.post(prio, std::move(cb)); });
    }
 
    executor_t& executor() {

--- a/include/appbase/application_instance.hpp
+++ b/include/appbase/application_instance.hpp
@@ -62,8 +62,8 @@ private:
 };
 
 // ------------------------------------------------------------------------------------------
-template <typename Data, typename DispatchPolicy>
-void channel<Data, DispatchPolicy>::publish(int priority, const Data& data) {
+template <typename Data, typename DispatchPolicy, typename Priority>
+void channel<Data, DispatchPolicy, Priority>::publish(Priority priority, const Data& data) {
    if (has_subscribers()) {
       // this will copy data into the lambda
       app().executor().post(priority, [this, data]() { _signal(data); });

--- a/include/appbase/channel.hpp
+++ b/include/appbase/channel.hpp
@@ -44,7 +44,7 @@ namespace appbase {
     *
     * @tparam Data - the type of data to publish
     */
-   template<typename Data, typename DispatchPolicy>
+   template<typename Data, typename DispatchPolicy, typename Priority>
    class channel final {
       public:
          /**
@@ -98,7 +98,7 @@ namespace appbase {
           * @param priority - the priority to use for post
           * @param data - the data to publish
           */
-         void publish(int priority, const Data& data);
+         void publish(Priority priority, const Data& data);
 
          /**
           * subscribe to data on a channel
@@ -180,9 +180,9 @@ namespace appbase {
     * @tparam Data - the typ of the Data the channel carries
     * @tparam DispatchPolicy - The dispatch policy to use for this channel (defaults to @ref drop_exceptions)
     */
-   template< typename Tag, typename Data, typename DispatchPolicy = drop_exceptions >
+   template< typename Tag, typename Data, typename Priority, typename DispatchPolicy = drop_exceptions >
    struct channel_decl {
-      using channel_type = channel<Data, DispatchPolicy>;
+      using channel_type = channel<Data, DispatchPolicy, Priority>;
       using tag_type = Tag;
    };
 

--- a/include/appbase/default_executor.hpp
+++ b/include/appbase/default_executor.hpp
@@ -8,7 +8,7 @@ namespace appbase {
 class default_executor {
 public:
    template <typename Func>
-   auto post(int priority, Func&& func) {
+   auto post(default_priority priority, Func&& func) {
       return boost::asio::post(io_serv, pri_queue.wrap(priority, std::forward<Func>(func)));
    }
 
@@ -43,7 +43,7 @@ public:
 private:
    // members are ordered taking into account that the last one is destructed first
    boost::asio::io_service io_serv;
-   execution_priority_queue pri_queue;
+   execution_priority_queue<default_priority> pri_queue;
 };
 
 } // namespace appbase


### PR DESCRIPTION
Make priority a template parameter, so that the user of appbase can use any class they want to store the information used to sort the tasks to be executed.