### PR TITLE
tweaks for standalone build; simple CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,28 @@
+name: "Build & Test"
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build-test:
+    name: Build & Test
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        os: ["debian:buster", "ubuntu:jammy"]
+    container: ${{matrix.os}}
+    steps:
+      - name: Install deps
+        run: |
+          apt-get update && apt-get upgrade -y
+          apt-get install -y build-essential cmake libboost-dev libboost-program-options-dev libboost-system-dev
+      - uses: actions/checkout@v3
+      - name: Build & Test
+        run: |
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+          cmake --build build -- -j $(nproc)
+          cd build && ctest --output-on-failure -j $(nproc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Defines AppBase library target.
-project( AppBase )
 cmake_minimum_required( VERSION 3.5 )
+project( AppBase )
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
 
@@ -21,7 +21,7 @@ set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 find_package(Threads)
 
-find_package(Boost 1.67 REQUIRED COMPONENTS program_options)
+find_package(Boost 1.67 REQUIRED COMPONENTS program_options system)
 
 if( APPLE )
   # Apple Specific Options Here
@@ -46,7 +46,12 @@ add_library( appbase
              ${HEADERS}
            )
 
-target_link_libraries( appbase Boost::program_options Threads::Threads)
+target_link_libraries( appbase PUBLIC Boost::program_options Boost::system Threads::Threads)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 8 AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9)
+    target_link_libraries( appbase PUBLIC stdc++fs )
+  endif()
+endif()
 
 target_include_directories( appbase
                             PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
@@ -82,4 +87,5 @@ install( TARGETS
 )
 
 add_subdirectory( examples )
+enable_testing()
 add_subdirectory( tests )


### PR DESCRIPTION
This adds some tweaks to build standalone with the currently stated minimums, and then adds a very simple CI running on Debian 10 & Ubuntu 22.04 to give a basic sniff test on if the library is building. I picked Debian 10 to be the "old" test because it mostly lines up with what the repo advertises as its minimum (Debian 10 has gcc8 & boost 1.67).

* `cmake_minimum_required()` needs to go first
* Prior to boost 1.69, boost System is a library that needs to be linked with for our usage here. In 1.69+ it's a stub library, so no harm in always including it. (notice Leap's pinned builds still have `--with-system`, and Leap's instructions just say to `apt-get install libboost-all-dev`)
* On gcc8 an extra library is needed for the std::filesystem usage. Kind of ugly to add this here in this way (it's not as precise as it really ought to be with a `try_compile()`), but doesn't seem like we'll be maintaining this configuration long anyways so I went with something quick.
* Add missing `enable_testing()`