### PR TITLE
rethrow exception from plugins initialization

### DIFF
--- a/application_base.cpp
+++ b/application_base.cpp
@@ -387,22 +387,22 @@ bool application_base::initialize_impl(int argc, char** argv, vector<abstract_pl
    if (initialize_logging)
       initialize_logging();
 
-   if(options.count("plugin") > 0)
-   {
-      auto plugins = options.at("plugin").as<std::vector<std::string>>();
-      for(auto& arg : plugins)
-      {
-         vector<string> names;
-         boost::split(names, arg, boost::is_any_of(" \t,"));
-         for(const std::string& name : names)
-            get_plugin(name).initialize(options);
-      }
-   }
-
    std::string plugin_name;
    auto error_header = [&]() { return std::string("appbase: exception thrown during plugin \"") + plugin_name + "\" initialization.\n"; };
 
    try {
+      if(options.count("plugin") > 0)
+      {
+         auto plugins = options.at("plugin").as<std::vector<std::string>>();
+         for(auto& arg : plugins)
+         {
+            vector<string> names;
+            boost::split(names, arg, boost::is_any_of(" \t,"));
+            for(const std::string& name : names)
+               get_plugin(name).initialize(options);
+         }
+      }
+
       for (auto plugin : autostart_plugins)
          if (plugin != nullptr && plugin->get_state() == abstract_plugin::registered) {
             plugin_name = plugin->name();
@@ -412,13 +412,13 @@ bool application_base::initialize_impl(int argc, char** argv, vector<abstract_pl
       bpo::notify(options);
    } catch ( const boost::exception& e ) {
       std::cerr << error_header() << boost::diagnostic_information(e) << "\n";
-      return false;
+      throw;
    } catch ( const std::exception& e ) {
       std::cerr << error_header() << e.what() << "\n";
-      return false;
+      throw;
    } catch (...) {
       std::cerr << error_header();
-      return false;
+      throw;
    }
 
    return true;


### PR DESCRIPTION
This PR rethrows all exceptions from plugin::initialize() so that the main() can return different return code based on the exception thrown.

Resolves [#1181](https://github.com/AntelopeIO/leap/issues/1181)