### PR TITLE
Ensure that `plugin_shutdown()` is always called.

### DIFF
--- a/include/appbase/application_base.hpp
+++ b/include/appbase/application_base.hpp
@@ -280,11 +280,11 @@ protected:
     * the application can call shutdown in the reverse order.
     */
    ///@{
-   void plugin_initialized(abstract_plugin& plug) {
-      initialized_plugins.push_back(&plug);
+   void plugin_initialized(abstract_plugin* plug) {
+      initialized_plugins.push_back(plug);
    }
-   void plugin_started(abstract_plugin& plug) {
-      running_plugins.push_back(&plug);
+   void plugin_started(abstract_plugin* plug) {
+      running_plugins.push_back(plug);
    }
    ///@}
 

--- a/include/appbase/application_instance.hpp
+++ b/include/appbase/application_instance.hpp
@@ -28,7 +28,7 @@ public:
          static_cast<Impl*>(this)->plugin_requires([&](auto& plug) { plug.initialize(options); });
          static_cast<Impl*>(this)->plugin_initialize(options);
          // ilog( "initializing plugin ${name}", ("name",name()) );
-         app().plugin_initialized(*this);
+         app().plugin_initialized(this);
       }
       assert(_state == initialized); /// if initial state was not registered, final state cannot be initialized
    }
@@ -39,8 +39,8 @@ public:
       if (_state == initialized) {
          _state = started;
          static_cast<Impl*>(this)->plugin_requires([&](auto& plug) { plug.startup(); });
+         app().plugin_started(this); // add to `running_plugins` before so it will be shutdown if we throw in `plugin_startup()`
          static_cast<Impl*>(this)->plugin_startup();
-         app().plugin_started(*this);
       }
       assert(_state == started); // if initial state was not initialized, final state cannot be started
    }


### PR DESCRIPTION
Even if there was an exception during `plugin_startup()`.

Resolves #25.

Currently, because a plugin is stored in the `running_plugins` list only after `plugin_startup()`, it would not be present if it throws during `plugin_startup()`, and as a consequence `plugin_shutdown()` would not be called on this plugin.

We need to make sure that `plugin_shutdown()` is called regardless of whether `plugin_startup()` completed successfully or not. That way, plugins can rest assured that whatever thread_pool or timer they started during `plugin_startup()` will be cleaned up, and no lambda referencing the plugin will be executed after the plugin is destroyed by the framework.

The fix is just flipping two lines in `abstract_plugin::startup()`. The rest is just adding a test to verify that the fix indeed works.

see parent issue  https://github.com/AntelopeIO/leap/issues/672.