### PR TITLE
Provide access to parsed options

### DIFF
--- a/include/appbase/application_base.hpp
+++ b/include/appbase/application_base.hpp
@@ -4,6 +4,7 @@
 #include <appbase/channel.hpp>
 #include <appbase/method.hpp>
 #include <boost/core/demangle.hpp>
+#include <boost/program_options/option.hpp>
 #include <typeindex>
 #include <exception>
 #include <string_view>
@@ -254,6 +255,7 @@ public:
    }
 
    const bpo::variables_map& get_options() const;
+   const std::vector<bpo::basic_option<char>>& get_parsed_options() const;
 
    /**
     * Set the current thread schedule priority to maximum.


### PR DESCRIPTION
Provides access to parsed command line and `config.ini` options.

Required by https://github.com/AntelopeIO/leap/pull/1412