### PR TITLE
fix appbase destruction order: destroy executor after destroying plugins

### DIFF
--- a/application_base.cpp
+++ b/application_base.cpp
@@ -88,8 +88,8 @@ class application_impl {
       std::optional<boost::asio::io_context> _signal_catching_io_ctx;
 };
 
-application_base::application_base()
-:my(new application_impl()){
+application_base::application_base(std::shared_ptr<void>&& e) :
+ executor_ptr(std::move(e)), my(new application_impl()){
    register_config_type<std::string>();
    register_config_type<bool>();
    register_config_type<unsigned short>();

--- a/include/appbase/application_base.hpp
+++ b/include/appbase/application_base.hpp
@@ -289,7 +289,10 @@ protected:
    }
    ///@}
 
-   application_base(); ///< protected because application is a singleton that should be accessed via instance()
+   application_base(std::shared_ptr<void>&& e); ///< protected because application is a singleton that should be accessed via instance()
+
+   /// !!! must be dtor'ed after plugins
+   std::shared_ptr<void> executor_ptr;
 
 private:
    // members are ordered taking into account that the last one is destructed first
@@ -368,7 +371,7 @@ public:
       application_base::startup(get_io_service());
    }
 
-   application_t() {
+   application_t() : application_base(std::make_shared<executor_t>()), executor_(*static_cast<executor_t*>(executor_ptr.get())) {
       set_stop_executor_cb([&]() { get_io_service().stop(); });
       set_post_cb([&](int prio, std::function<void()> cb) { executor_.post(prio, std::move(cb)); });
    }
@@ -379,7 +382,7 @@ public:
 
 private:
    inline static std::unique_ptr<application_t> app_instance;
-   executor_t executor_;
+   executor_t& executor_;
 };
 
 

--- a/include/appbase/application_base.hpp
+++ b/include/appbase/application_base.hpp
@@ -352,7 +352,7 @@ public:
     */
    template <typename Func>
    auto post(int priority, Func&& func) {
-      return get_executor().post(priority, std::forward<Func>(func));
+      return executor().post(priority, std::forward<Func>(func));
    }
 
    /**
@@ -360,11 +360,11 @@ public:
     *  Should only be executed from one thread.
     */
    void exec() {
-      application_base::exec(get_executor());
+      application_base::exec(executor());
    }
 
    boost::asio::io_service& get_io_service() {
-      return get_executor().get_io_service();
+      return executor().get_io_service();
    }
 
    void startup() {
@@ -373,19 +373,15 @@ public:
 
    application_t() : application_base(std::make_shared<executor_t>()) {
       set_stop_executor_cb([&]() { get_io_service().stop(); });
-      set_post_cb([&](int prio, std::function<void()> cb) { get_executor().post(prio, std::move(cb)); });
+      set_post_cb([&](int prio, std::function<void()> cb) { executor().post(prio, std::move(cb)); });
    }
 
-   executor_t& executor() {
-      return get_executor();
+   executor_t& executor() const {
+      return *static_cast<executor_t*>(executor_ptr.get());
    }
 
 private:
    inline static std::unique_ptr<application_t> app_instance;
-
-   executor_t& get_executor() const {
-      return *static_cast<executor_t*>(executor_ptr.get());
-   }
 };
 
 


### PR DESCRIPTION
A user of appbase will instantiate an appbase via a scoped_app,
https://github.com/AntelopeIO/appbase/blob/b75b31e14f966fa3de6246e120dcba36c6ce5264/include/appbase/application_instance.hpp#L76-L84
https://github.com/AntelopeIO/appbase/blob/b75b31e14f966fa3de6246e120dcba36c6ce5264/include/appbase/application_instance.hpp#L101-L103
`application` will either be
https://github.com/AntelopeIO/appbase/blob/b75b31e14f966fa3de6246e120dcba36c6ce5264/include/appbase/application.hpp#L19
or possibly a user defined executor (as leap uses). In either case, a `application_t<>` instance will be created and destroyed in unison with the scope of the `scoped_app`.

`application_t` derives from `application_base`,
https://github.com/AntelopeIO/appbase/blob/b75b31e14f966fa3de6246e120dcba36c6ce5264/include/appbase/application_base.hpp#L324-L325
and `application_t` contains a member that is the executor,
https://github.com/AntelopeIO/appbase/blob/b75b31e14f966fa3de6246e120dcba36c6ce5264/include/appbase/application_base.hpp#L386-L388
However, it's `application_base` that stores the plugins,
https://github.com/AntelopeIO/appbase/blob/b75b31e14f966fa3de6246e120dcba36c6ce5264/include/appbase/application_base.hpp#L306

This means that when `application_t` is destroyed the executor is destroyed _and then_ plugins are destroyed. But plugins can still interact with the now destroyed executor as they themselves are destroyed (consider, for example, `producer_plugin_impl`'s `_timer` which took a reference to the appbase executor's io_context and is destroyed when producer_plugin is destroyed)

Instead, bundle the executor inside the `application_base` so it isn't destroyed until after the plugins.