### PR TITLE
Fix missing plugin name in exception message when a plugin fails to initialize

### DIFF
--- a/application_base.cpp
+++ b/application_base.cpp
@@ -402,8 +402,10 @@ bool application_base::initialize_impl(int argc, char** argv, vector<abstract_pl
          {
             vector<string> names;
             boost::split(names, arg, boost::is_any_of(" \t,"));
-            for(const std::string& name : names)
+            for(const std::string& name : names) {
+               plugin_name = name;
                get_plugin(name).initialize(options);
+            }
          }
       }
 


### PR DESCRIPTION
https://github.com/AntelopeIO/spring/issues/155 reports seeing
`appbase: exception thrown during plugin "" initialization.`

I saw when dirty db happened:
```

   N5boost10wrapexceptISt12system_errorEE: Database dirty flag set
 rethrow Database dirty flag set:
    {"what":"Database dirty flag set"}
      nodeos  chain_plugin.cpp:1097 plugin_initialize
 
 appbase: exception thrown during plugin "" initialization.
```