### PR TITLE
Drain io_context after shutdown of plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ Plugins can be registered by calling `appbase::application::register_plugin()`. 
 ### Boost ASIO 
 
 AppBase maintains a singleton `application` instance which can be accessed via `appbase::app()`.  This 
-application owns a `boost::asio::io_service` which starts running when `appbase::exec()` is called. If 
+application owns a `boost::asio::io_context` which starts running when `appbase::exec()` is called. If 
 a plugin needs to perform IO or other asynchronous operations then it should dispatch it via `application`
-`io_service` which is setup to use an execution priority queue.
+`io_context` which is setup to use an execution priority queue.
 ```
 app().post( appbase::priority::low, lambda )
 ```
@@ -104,10 +104,10 @@ OR
 ```
 delay_timer->async_wait( app().get_priority_queue().wrap( priority::low, lambda ) );
 ```
-Use of `get_io_service()` directly is not recommended as the priority queue will not be respected. 
+Use of `get_io_context()` directly is not recommended as the priority queue will not be respected. 
 
-Because the app calls `io_service::run()` from within `application::exec()` and does not spawn any threads
-all asynchronous operations posted to the io_service should be run in the same thread.  
+Because the app calls `io_context::run()` from within `application::exec()` and does not spawn any threads
+all asynchronous operations posted to the io_context should be run in the same thread.  
 
 ## Graceful Exit 
 

--- a/application_base.cpp
+++ b/application_base.cpp
@@ -152,7 +152,7 @@ void application_base::wait_for_signal(std::shared_ptr<boost::asio::signal_set> 
    });
 }
 
-void application_base::setup_signal_handling_on_ios(boost::asio::io_context& io_ctx, bool startup) {
+void application_base::setup_signal_handling_on_ioc(boost::asio::io_context& io_ctx, bool startup) {
    std::shared_ptr<boost::asio::signal_set> ss = std::make_shared<boost::asio::signal_set>(io_ctx, SIGINT, SIGTERM);
 #ifdef SIGPIPE
    ss->add(SIGPIPE);
@@ -168,7 +168,7 @@ void application_base::setup_signal_handling_on_ios(boost::asio::io_context& io_
 void application_base::startup(boost::asio::io_context& io_ctx) {
    //during startup, run a second thread to catch SIGINT/SIGTERM/SIGPIPE/SIGHUP
    boost::asio::io_context startup_thread_io_ctx;
-   setup_signal_handling_on_ios(startup_thread_io_ctx, true);
+   setup_signal_handling_on_ioc(startup_thread_io_ctx, true);
    std::thread startup_thread([&startup_thread_io_ctx]() {
       startup_thread_io_ctx.run();
    });
@@ -191,7 +191,7 @@ void application_base::startup(boost::asio::io_context& io_ctx) {
 
    //after startup, shut down the signal handling thread and catch the signals back on main io_context
    clean_up_signal_thread();
-   setup_signal_handling_on_ios(io_ctx, false);
+   setup_signal_handling_on_ioc(io_ctx, false);
 
 #ifdef SIGHUP
    std::shared_ptr<boost::asio::signal_set> sighup_set(new boost::asio::signal_set(io_ctx, SIGHUP));

--- a/application_base.cpp
+++ b/application_base.cpp
@@ -468,7 +468,6 @@ void application_base::shutdown() {
    try {
       running_plugins.clear();
       initialized_plugins.clear();
-      plugins.clear();
    } catch(...) {
       if (!eptr)
          eptr = std::current_exception();

--- a/examples/executor_example/application.hpp
+++ b/examples/executor_example/application.hpp
@@ -24,7 +24,7 @@ class my_executor {
 public:
    template <typename Func>
    auto post( int priority, Func&& func ) {
-      return boost::asio::post(io_serv, pri_queue.wrap(priority, --order, std::forward<Func>(func)));
+      return boost::asio::post(io_ctx, pri_queue.wrap(priority, --order, std::forward<Func>(func)));
    }
 
    auto& get_priority_queue() { return pri_queue; }
@@ -33,11 +33,11 @@ public:
      
    void clear() { pri_queue.clear(); }
 
-   boost::asio::io_service& get_io_service() { return io_serv; }
+   boost::asio::io_context& get_io_context() { return io_ctx; }
 
 private:
    // members are ordered taking into account that the last one is destructed first
-   boost::asio::io_context io_serv;
+   boost::asio::io_context io_ctx;
    appbase::execution_priority_queue pri_queue;
    std::size_t order = std::numeric_limits<size_t>::max(); // to maintain FIFO ordering in queue within priority
 };

--- a/examples/executor_example/application.hpp
+++ b/examples/executor_example/application.hpp
@@ -19,13 +19,12 @@
 #include <appbase/execution_priority_queue.hpp>
 
 #include <limits>
-#include <optional>
 
 class my_executor {
 public:
    template <typename Func>
    auto post( int priority, Func&& func ) {
-      return boost::asio::post(*io_serv, pri_queue.wrap(priority, --order, std::forward<Func>(func)));
+      return boost::asio::post(io_serv, pri_queue.wrap(priority, --order, std::forward<Func>(func)));
    }
 
    auto& get_priority_queue() { return pri_queue; }
@@ -34,13 +33,11 @@ public:
      
    void clear() { pri_queue.clear(); }
 
-   void reset() { io_serv.emplace(); }
-
-   boost::asio::io_service& get_io_service() { return *io_serv; }
+   boost::asio::io_service& get_io_service() { return io_serv; }
 
 private:
    // members are ordered taking into account that the last one is destructed first
-   std::optional<boost::asio::io_service> io_serv{std::in_place};
+   boost::asio::io_context io_serv;
    appbase::execution_priority_queue pri_queue;
    std::size_t order = std::numeric_limits<size_t>::max(); // to maintain FIFO ordering in queue within priority
 };

--- a/examples/executor_example/application.hpp
+++ b/examples/executor_example/application.hpp
@@ -18,6 +18,9 @@
 #include <appbase/application_base.hpp>
 #include <appbase/execution_priority_queue.hpp>
 
+#include <limits>
+#include <optional>
+
 class my_executor {
 public:
    template <typename Func>

--- a/examples/executor_example/application.hpp
+++ b/examples/executor_example/application.hpp
@@ -22,7 +22,7 @@ class my_executor {
 public:
    template <typename Func>
    auto post( int priority, Func&& func ) {
-      return boost::asio::post(io_serv, pri_queue.wrap(priority, --order, std::forward<Func>(func)));
+      return boost::asio::post(*io_serv, pri_queue.wrap(priority, --order, std::forward<Func>(func)));
    }
 
    auto& get_priority_queue() { return pri_queue; }
@@ -31,11 +31,13 @@ public:
      
    void clear() { pri_queue.clear(); }
 
-   boost::asio::io_service& get_io_service() { return io_serv; }
+   void reset() { io_serv.emplace(); }
+
+   boost::asio::io_service& get_io_service() { return *io_serv; }
 
 private:
    // members are ordered taking into account that the last one is destructed first
-   boost::asio::io_service  io_serv;
+   std::optional<boost::asio::io_service> io_serv{std::in_place};
    appbase::execution_priority_queue pri_queue;
    std::size_t order = std::numeric_limits<size_t>::max(); // to maintain FIFO ordering in queue within priority
 };

--- a/include/appbase/application_base.hpp
+++ b/include/appbase/application_base.hpp
@@ -152,13 +152,13 @@ public:
          }
 
          work.reset();
-         io_serv.restart();
-         // plugins shutdown down, drain io_context of anything posted while shutting down before destroying plugins
-         while (io_serv.poll())
-            ;
 
          try {
+            // plugins shutdown down at this point,
             exec.clear(); // make sure the queue is empty
+            // Recreate the io_context since it doesn't provide a clear and we want the destructors of all the
+            // lambdas posted to the io_context to execute before destroying the plugins
+            exec.reset();
             destroy_plugins();
          } catch (...) {
             if (!eptr)

--- a/include/appbase/application_base.hpp
+++ b/include/appbase/application_base.hpp
@@ -144,6 +144,8 @@ public:
             }
          }
 
+         quit();
+
          try {
             shutdown_plugins();   // may rethrow exceptions
          } catch (...) {

--- a/include/appbase/application_base.hpp
+++ b/include/appbase/application_base.hpp
@@ -342,7 +342,7 @@ private:
    void print_default_config(std::ostream& os);
 
    void wait_for_signal(std::shared_ptr<boost::asio::signal_set> ss);
-   void setup_signal_handling_on_ios(boost::asio::io_context& io_ctx, bool startup);
+   void setup_signal_handling_on_ioc(boost::asio::io_context& io_ctx, bool startup);
 
    void handle_exception(std::exception_ptr eptr, std::string_view origin);
 };

--- a/include/appbase/application_base.hpp
+++ b/include/appbase/application_base.hpp
@@ -397,6 +397,22 @@ public:
       return executor().get_io_service();
    }
 
+   /**
+    * Create a timer with the main application io_context. Timer async_wait will execute on the main thread.
+    *
+    * Use with app().executor().wrap(priority::x, exec_queue::x, [](const boost::system::error_code& ec).
+    * For example:
+    *   _timer.async_wait(app().executor().wrap(priority::high, exec_queue::read_write,
+    *                                           [](const boost::system::error_code& ec) {
+    *                                              if (!ec)
+    *                                                 // do something
+    *                                           }));
+    */
+   template<typename Timer>
+   auto make_timer() {
+      return Timer{get_io_service()};
+   }
+
    void startup() {
       application_base::startup(get_io_service());
    }

--- a/include/appbase/application_base.hpp
+++ b/include/appbase/application_base.hpp
@@ -145,7 +145,7 @@ public:
          }
 
          try {
-            shutdown();   // may rethrow exceptions
+            shutdown_plugins();   // may rethrow exceptions
          } catch (...) {
             if (!eptr)
                eptr = std::current_exception();
@@ -159,7 +159,7 @@ public:
 
          try {
             exec.clear(); // make sure the queue is empty
-            plugins.clear();
+            destroy_plugins();
          } catch (...) {
             if (!eptr)
                eptr = std::current_exception();
@@ -302,7 +302,8 @@ protected:
    }
    ///@}
 
-   void shutdown();
+   void shutdown_plugins();
+   void destroy_plugins();
 
    application_base(std::shared_ptr<void>&& e); ///< protected because application is a singleton that should be accessed via instance()
 

--- a/include/appbase/default_executor.hpp
+++ b/include/appbase/default_executor.hpp
@@ -4,7 +4,6 @@
 #include <appbase/execution_priority_queue.hpp>
 
 #include <limits>
-#include <optional>
 
 namespace appbase {
 
@@ -12,7 +11,7 @@ class default_executor {
 public:
    template <typename Func>
    auto post(int priority, Func&& func) {
-      return boost::asio::post(*io_serv, pri_queue.wrap(priority, --order, std::forward<Func>(func)));
+      return boost::asio::post(io_serv, pri_queue.wrap(priority, --order, std::forward<Func>(func)));
    }
 
    /**
@@ -35,21 +34,17 @@ public:
       pri_queue.clear();
    }
 
-   void reset() {
-      io_serv.emplace();
-   }
-
    /**
     * Do not run io_service in any other threads, as application assumes single-threaded execution in exec().
     * @return io_serivice of application
     */
    boost::asio::io_service& get_io_service() {
-      return *io_serv;
+      return io_serv;
    }
 
 private:
    // members are ordered taking into account that the last one is destructed first
-   std::optional<boost::asio::io_service> io_serv{std::in_place};
+   boost::asio::io_context  io_serv;
    execution_priority_queue pri_queue;
    std::size_t order = std::numeric_limits<size_t>::max(); // to maintain FIFO ordering in queue within priority
 };

--- a/include/appbase/default_executor.hpp
+++ b/include/appbase/default_executor.hpp
@@ -3,6 +3,9 @@
 #include <appbase/application_base.hpp>
 #include <appbase/execution_priority_queue.hpp>
 
+#include <limits>
+#include <optional>
+
 namespace appbase {
 
 class default_executor {

--- a/include/appbase/default_executor.hpp
+++ b/include/appbase/default_executor.hpp
@@ -11,7 +11,7 @@ class default_executor {
 public:
    template <typename Func>
    auto post(int priority, Func&& func) {
-      return boost::asio::post(io_serv, pri_queue.wrap(priority, --order, std::forward<Func>(func)));
+      return boost::asio::post(io_ctx, pri_queue.wrap(priority, --order, std::forward<Func>(func)));
    }
 
    /**
@@ -19,7 +19,7 @@ public:
     * prioritized execution.
     *
     * Example:
-    *   boost::asio::steady_timer timer( app().get_io_service() );
+    *   boost::asio::steady_timer timer( app().get_io_context() );
     *   timer.async_wait( app().get_priority_queue().wrap(priority::low, [](){ do_something(); }) );
     */
    auto& get_priority_queue() {
@@ -35,16 +35,16 @@ public:
    }
 
    /**
-    * Do not run io_service in any other threads, as application assumes single-threaded execution in exec().
-    * @return io_serivice of application
+    * Do not run io_context in any other threads, as application assumes single-threaded execution in exec().
+    * @return io_context of application
     */
-   boost::asio::io_service& get_io_service() {
-      return io_serv;
+   boost::asio::io_context& get_io_context() {
+      return io_ctx;
    }
 
 private:
    // members are ordered taking into account that the last one is destructed first
-   boost::asio::io_context  io_serv;
+   boost::asio::io_context  io_ctx;
    execution_priority_queue pri_queue;
    std::size_t order = std::numeric_limits<size_t>::max(); // to maintain FIFO ordering in queue within priority
 };

--- a/tests/shutdown_test.cpp
+++ b/tests/shutdown_test.cpp
@@ -26,7 +26,7 @@ class thready_plugin : public appbase::plugin<thready_plugin> {
      void thread_work() {
         boost::asio::post(ctx, [&]() {
            thing_better_be_alive better_be;
-           boost::asio::post(appbase::app().get_io_service(), [&,is_it=std::move(better_be)]() {
+           boost::asio::post(appbase::app().get_io_context(), [&,is_it=std::move(better_be)]() {
 	      thread_work();
 	   });
 	});
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE(test_shutdown)
    if( !app->initialize<thready_plugin>( 1, const_cast<char**>(argv) ) )
       return;
    app->startup();
-   boost::asio::post(appbase::app().get_io_service(), [&](){
+   boost::asio::post(appbase::app().get_io_context(), [&](){
       std::this_thread::sleep_for(std::chrono::milliseconds(5));
       app->quit();
    });

--- a/tests/shutdown_test.cpp
+++ b/tests/shutdown_test.cpp
@@ -1,0 +1,79 @@
+#include <appbase/application.hpp>
+#include <thread>
+
+#include <boost/test/unit_test.hpp>
+
+namespace bpo = boost::program_options;
+using bpo::options_description;
+using bpo::variables_map;
+
+static bool thing = true;
+struct thing_better_be_alive {
+   ~thing_better_be_alive() noexcept(false) {
+      if(!thing)
+         throw "BOOM";
+   }
+};
+
+class thready_plugin : public appbase::plugin<thready_plugin> {
+   public:
+
+     template <typename Lambda>
+     void plugin_requires(Lambda&& l) {}
+
+     void set_program_options( options_description& cli, options_description& cfg ) override {}
+
+     void thread_work() {
+        boost::asio::post(ctx, [&]() {
+           thing_better_be_alive better_be;
+           boost::asio::post(appbase::app().get_io_service(), [&,is_it=std::move(better_be)]() {
+	      thread_work();
+	   });
+	});
+     }
+
+     void plugin_initialize( const variables_map& options ) {}
+     void plugin_startup()  {
+        for(unsigned i = 0; i < 48*4; i++)
+           thread_work();
+
+        for(unsigned i = 0; i < 48; ++i)
+           threads.emplace_back([this]() {
+              ctx.run();
+           });
+     }
+     void plugin_shutdown() {
+        usleep(100000);  //oh gee it takes a while to stop
+        ctx.stop();
+        for(unsigned i = 0; i < 48; ++i)
+          threads[i].join();
+     }
+
+     ~thready_plugin() {
+        thing = false;
+     }
+
+     boost::asio::io_context ctx;
+     boost::asio::executor_work_guard<boost::asio::io_context::executor_type> wg = boost::asio::make_work_guard(ctx);
+
+   private:
+     std::vector<std::thread> threads;
+};
+
+
+BOOST_AUTO_TEST_CASE(test_shutdown)
+{
+   appbase::application::register_plugin<thready_plugin>();
+   appbase::scoped_app app;
+
+   const char* argv[] = { "nodoes" };
+   if( !app->initialize<thready_plugin>( 1, const_cast<char**>(argv) ) )
+      return;
+   app->startup();
+   boost::asio::post(appbase::app().get_io_service(), [&](){
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+      app->quit();
+   });
+   app->exec();
+   
+}


### PR DESCRIPTION
This solves the problem of hang on shutdown of nodeos. See https://github.com/AntelopeIO/spring/issues/822.

Make sure to clear to the `io_context` after shutdown of the plugins. Also it uses `stopped()` of `io_context` instead of the application `is_quiting()` to avoid exiting the loop early.

Example failure: https://github.com/AntelopeIO/spring/actions/runs/11075714563
Example with this PR: https://github.com/AntelopeIO/spring/actions/runs/11076069453

Needs https://github.com/AntelopeIO/spring/issues/842