### PR TITLE
Use stopped() instead of quit flag to exit exec loop

### DIFF
--- a/include/appbase/application_base.hpp
+++ b/include/appbase/application_base.hpp
@@ -131,10 +131,10 @@ public:
          bool more = true;
 
          while (more || io_serv.run_one()) {
-            if (is_quiting())
-               break;
             try {
                io_serv.poll(); // queue up any ready; allowing high priority item to get into the queue
+               if (io_serv.stopped())
+                  break;
                // execute the highest priority item
                more = exec.execute_highest();
             } catch (...) {


### PR DESCRIPTION
By checking `is_quitting()` before calling `poll()` there is the possibility that something was posted but not drained to the priority queue. Instead use the `io_context` `stopped()` to break out of the loop after calling `poll()`.