### PR TITLE
Handle signals, except SIGHUP, off the main thread

### DIFF
--- a/include/appbase/application_base.hpp
+++ b/include/appbase/application_base.hpp
@@ -342,7 +342,7 @@ private:
    void print_default_config(std::ostream& os);
 
    void wait_for_signal(std::shared_ptr<boost::asio::signal_set> ss);
-   void setup_signal_handling_on_ioc(boost::asio::io_context& io_ctx, bool startup);
+   std::shared_ptr<boost::asio::signal_set> setup_signal_handling_on_ioc(boost::asio::io_context& io_ctx, bool include_sighup);
 
    void handle_exception(std::exception_ptr eptr, std::string_view origin);
 };


### PR DESCRIPTION
Since signals are used to interrupt execution, handle them on a different thread so that they can interrupt the main thread execution if desired.