### PR TITLE
Only call stop_executor_cb once on signal

### DIFF
--- a/application_base.cpp
+++ b/application_base.cpp
@@ -483,8 +483,9 @@ void application_base::destroy_plugins() {
 }
 
 void application_base::quit() {
-   my->_is_quiting = true;
-   stop_executor_cb();
+   const bool already_quitting = my->_is_quiting.exchange(true);
+   if (!already_quitting)
+      stop_executor_cb();
 }
 
 bool application_base::is_quiting() const {


### PR DESCRIPTION
Spring https://github.com/AntelopeIO/spring/issues/1074 is an instance where `quit()` was called during shutdown which called `stop_exectur_cb` which tried to access the `controller` after it was destroyed. Update `quit()` to not call `stop_executor_cb()` if it has already been called.