### PR TITLE
opt in to cmake policies through 3.31 to silence cmake warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Defines AppBase library target.
-cmake_minimum_required( VERSION 3.5 )
+cmake_minimum_required( VERSION 3.8...3.31 )
 project( AppBase )
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")


### PR DESCRIPTION
appbase requires c++17 which was first supported in cmake 3.8 so bump minimum version supported to 3.8. Also opt in for cmake policies through 3.31 to silence a warning that is showing up in latest cmake
```
CMake Deprecation Warning at libraries/appbase/CMakeLists.txt:2 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.
```
(alternatively could possibly just opt in to CMP0167 instead of all the way through 3.31 but this seems fine..)