### PR TITLE
Handle signals during plugin_initialize

### DIFF
--- a/application_base.cpp
+++ b/application_base.cpp
@@ -373,7 +373,7 @@ bool application_base::initialize_impl(int argc, char** argv, vector<abstract_pl
    std::string plugin_name;
    auto error_header = [&]() { return std::string("appbase: exception thrown during plugin \"") + plugin_name + "\" initialization.\n"; };
 
-   // setup handling of SIGINT/SIGTERM/SIGPIPE/SIGHUP during initialize
+   // setup handling of SIGINT/SIGTERM/SIGPIPE during initialize
    auto ss = setup_signal_handling_on_ioc(my->_signal_catching_io_ctx);
 
    try {

--- a/application_base.cpp
+++ b/application_base.cpp
@@ -151,24 +151,16 @@ void application_base::wait_for_signal(std::shared_ptr<boost::asio::signal_set> 
    });
 }
 
-std::shared_ptr<boost::asio::signal_set> application_base::setup_signal_handling_on_ioc(boost::asio::io_context& io_ctx, bool include_sighup) {
+std::shared_ptr<boost::asio::signal_set> application_base::setup_signal_handling_on_ioc(boost::asio::io_context& io_ctx) {
    std::shared_ptr<boost::asio::signal_set> ss = std::make_shared<boost::asio::signal_set>(io_ctx, SIGINT, SIGTERM);
 #ifdef SIGPIPE
    ss->add(SIGPIPE);
-#endif
-#ifdef SIGHUP
-   if( include_sighup ) {
-      ss->add(SIGHUP);
-   }
 #endif
    wait_for_signal(ss);
    return ss;
 }
 
 void application_base::startup(boost::asio::io_context& io_ctx) {
-   // setup handling of SIGINT/SIGTERM/SIGPIPE/SIGHUP during startup
-   auto ss = setup_signal_handling_on_ioc(my->_signal_catching_io_ctx, true);
-
    try {
       for( auto plugin : initialized_plugins ) {
          if( is_quiting() ) break;
@@ -179,11 +171,6 @@ void application_base::startup(boost::asio::io_context& io_ctx) {
       shutdown_plugins();
       throw;
    }
-
-   //after startup, move SIGHUP handling to main thread
-   boost::system::error_code ec;
-   ss->cancel(ec);
-   setup_signal_handling_on_ioc(my->_signal_catching_io_ctx, false);
 
 #ifdef SIGHUP
    std::shared_ptr<boost::asio::signal_set> sighup_set(new boost::asio::signal_set(io_ctx, SIGHUP));
@@ -385,6 +372,9 @@ bool application_base::initialize_impl(int argc, char** argv, vector<abstract_pl
 
    std::string plugin_name;
    auto error_header = [&]() { return std::string("appbase: exception thrown during plugin \"") + plugin_name + "\" initialization.\n"; };
+
+   // setup handling of SIGINT/SIGTERM/SIGPIPE/SIGHUP during initialize
+   auto ss = setup_signal_handling_on_ioc(my->_signal_catching_io_ctx);
 
    try {
       if(options.count("plugin") > 0)

--- a/include/appbase/application_base.hpp
+++ b/include/appbase/application_base.hpp
@@ -342,7 +342,7 @@ private:
    void print_default_config(std::ostream& os);
 
    void wait_for_signal(std::shared_ptr<boost::asio::signal_set> ss);
-   std::shared_ptr<boost::asio::signal_set> setup_signal_handling_on_ioc(boost::asio::io_context& io_ctx, bool include_sighup);
+   std::shared_ptr<boost::asio::signal_set> setup_signal_handling_on_ioc(boost::asio::io_context& io_ctx);
 
    void handle_exception(std::exception_ptr eptr, std::string_view origin);
 };


### PR DESCRIPTION
Spring creates the `controller` in `chain_plugin::plugin_initialize`. If ctrl-c is pressed during `chain_plugin::plugin_initialize` `chainbase` can be left with a dirty-db flag. 

- Move initialization of signal handing to `appbase::initialize` so that it is in affect during `plugin_initialize`.
- Do not cancel and restart the `signal_set` to remove `SIGHUP` from the signal set. This was technically not thread-safe before. The boost docs indicate shared objects are not thread-safe. Since we discussed before that there was no real reason to treat `SIGHUP` differently during startup, I just removed the cancel/restart. This makes it thread-safe and simplifies the implementation.